### PR TITLE
Combine Sink::{poll, output}

### DIFF
--- a/amadeus-core/src/into_par_stream/collections.rs
+++ b/amadeus-core/src/into_par_stream/collections.rs
@@ -13,6 +13,7 @@ impl<'a, 'b, I: Iterator<Item = (&'a A, &'b B)>, A: Clone + 'a, B: Clone + 'b> I
 	for TupleCloned<I>
 {
 	type Item = (A, B);
+
 	fn next(&mut self) -> Option<Self::Item> {
 		self.0.next().map(|(a, b)| (a.clone(), b.clone()))
 	}

--- a/amadeus-core/src/into_par_stream/iterator.rs
+++ b/amadeus-core/src/into_par_stream/iterator.rs
@@ -21,6 +21,7 @@ pub trait IteratorExt: Iterator + Sized {
 impl<I: Iterator + Sized> IteratorExt for I {}
 
 impl_par_dist_rename! {
+	#[pin_project]
 	pub struct IterParStream<I>(pub(crate) I);
 
 	impl<I: Iterator> ParallelStream for IterParStream<I>
@@ -33,8 +34,8 @@ impl_par_dist_rename! {
 		fn size_hint(&self) -> (usize, Option<usize>) {
 			self.0.size_hint()
 		}
-		fn next_task(&mut self) -> Option<Self::Task> {
-			self.0.next().map(IterStreamTask::new)
+		fn next_task(mut self: Pin<&mut Self>, _cx: &mut Context) -> Poll<Option<Self::Task>> {
+			Poll::Ready(self.0.next().map(IterStreamTask::new))
 		}
 	}
 }

--- a/amadeus-core/src/into_par_stream/slice.rs
+++ b/amadeus-core/src/into_par_stream/slice.rs
@@ -47,7 +47,7 @@ impl_par_dist_rename! {
 		fn size_hint(&self) -> (usize, Option<usize>) {
 			unreachable!()
 		}
-		fn next_task(&mut self) -> Option<Self::Task> {
+		fn next_task(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<Option<Self::Task>> {
 			unreachable!()
 		}
 	}

--- a/amadeus-core/src/par_pipe.rs
+++ b/amadeus-core/src/par_pipe.rs
@@ -5,14 +5,13 @@ use futures::Stream;
 use serde_closure::traits;
 use std::{cmp::Ordering, hash::Hash, iter, ops};
 
+use super::{par_sink::*, par_stream::*};
 use crate::{pipe::Pipe, pool::ProcessSend};
 
-use super::{par_sink::*, par_stream::*};
-
 #[must_use]
-pub trait PipeTask<Source> {
-	type Item;
-	type Async: Pipe<Source, Item = Self::Item>;
+pub trait PipeTask<Input> {
+	type Output;
+	type Async: Pipe<Input, Output = Self::Output>;
 
 	fn into_async(self) -> Self::Async;
 }
@@ -21,15 +20,15 @@ macro_rules! pipe {
 	($pipe:ident $sink:ident $from_sink:ident $send:ident $fns:ident $assert_pipe:ident $assert_sink:ident $($meta:meta)*) => {
 		$(#[$meta])*
 		#[must_use]
-		pub trait $pipe<Source> {
-			type Item;
-			type Task: PipeTask<Source, Item = Self::Item> + $send;
+		pub trait $pipe<Input> {
+			type Output;
+			type Task: PipeTask<Input, Output = Self::Output> + $send;
 
 			fn task(&self) -> Self::Task;
 
 			fn inspect<F>(self, f: F) -> Inspect<Self, F>
 			where
-				F: $fns::FnMut(&Self::Item) + Clone + $send + 'static,
+				F: $fns::FnMut(&Self::Output) + Clone + $send + 'static,
 				Self: Sized,
 			{
 				$assert_pipe(Inspect::new(self, f))
@@ -37,7 +36,7 @@ macro_rules! pipe {
 
 			fn update<F>(self, f: F) -> Update<Self, F>
 			where
-				F: $fns::FnMut(&mut Self::Item) + Clone + $send + 'static,
+				F: $fns::FnMut(&mut Self::Output) + Clone + $send + 'static,
 				Self: Sized,
 			{
 				$assert_pipe(Update::new(self, f))
@@ -45,7 +44,7 @@ macro_rules! pipe {
 
 			fn map<B, F>(self, f: F) -> Map<Self, F>
 			where
-				F: $fns::FnMut(Self::Item) -> B + Clone + $send + 'static,
+				F: $fns::FnMut(Self::Output) -> B + Clone + $send + 'static,
 				Self: Sized,
 			{
 				$assert_pipe(Map::new(self, f))
@@ -53,7 +52,7 @@ macro_rules! pipe {
 
 			fn flat_map<B, F>(self, f: F) -> FlatMap<Self, F>
 			where
-				F: $fns::FnMut(Self::Item) -> B + Clone + $send + 'static,
+				F: $fns::FnMut(Self::Output) -> B + Clone + $send + 'static,
 				B: Stream,
 				Self: Sized,
 			{
@@ -62,17 +61,17 @@ macro_rules! pipe {
 
 			fn filter<F>(self, f: F) -> Filter<Self, F>
 			where
-				F: $fns::FnMut(&Self::Item) -> bool + Clone + $send + 'static,
+				F: $fns::FnMut(&Self::Output) -> bool + Clone + $send + 'static,
 				Self: Sized,
 			{
 				$assert_pipe(Filter::new(self, f))
 			}
 
-			fn cloned<'a, T>(self) -> Cloned<Self, T, Source>
+			fn cloned<'a, T>(self) -> Cloned<Self, T, Input>
 			where
 				T: Clone + 'a,
-				Source: 'a,
-				Self: $pipe<&'a Source, Item = &'a T> + Sized,
+				Input: 'a,
+				Self: $pipe<&'a Input, Output = &'a T> + Sized,
 			{
 				$assert_pipe(Cloned::new(self))
 			}
@@ -80,7 +79,7 @@ macro_rules! pipe {
 			// #[must_use]
 			// fn chain<C>(self, chain: C) -> Chain<Self, C::Iter>
 			// where
-			// 	C: IntoParallelStream<Item = Self::Item>,
+			// 	C: IntoParallelStream<Output = Self::Output>,
 			// 	Self: Sized,
 			// {
 			// 	$assert_pipe(Chain::new(self, chain.into_par_stream()))
@@ -88,7 +87,7 @@ macro_rules! pipe {
 
 			fn pipe<S>(self, sink: S) -> super::par_sink::Pipe<Self, S>
 			where
-				S: $sink<Self::Item>,
+				S: $sink<Self::Output>,
 				Self: Sized,
 			{
 				$assert_sink(super::par_sink::Pipe::new(self, sink))
@@ -96,10 +95,10 @@ macro_rules! pipe {
 
 			fn fork<A, B, RefAItem>(
 				self, sink: A, sink_ref: B,
-			) -> Fork<Self, A, B, &'static Self::Item>
+			) -> Fork<Self, A, B, &'static Self::Output>
 			where
-				A: $sink<Self::Item>,
-				B: for<'a> $sink<&'a Self::Item>,
+				A: $sink<Self::Output>,
+				B: for<'a> $sink<&'a Self::Output>,
 				Self: Sized,
 			{
 				$assert_sink(Fork::new(self, sink, sink_ref))
@@ -107,7 +106,7 @@ macro_rules! pipe {
 
 			fn for_each<F>(self, f: F) -> ForEach<Self, F>
 			where
-				F: $fns::FnMut(Self::Item) + Clone + $send + 'static,
+				F: $fns::FnMut(Self::Output) + Clone + $send + 'static,
 				Self: Sized,
 			{
 				$assert_sink(ForEach::new(self, f))
@@ -116,7 +115,7 @@ macro_rules! pipe {
 			fn fold<ID, F, B>(self, identity: ID, op: F) -> Fold<Self, ID, F, B>
 			where
 				ID: $fns::FnMut() -> B + Clone + $send + 'static,
-				F: $fns::FnMut(B, Either<Self::Item, B>) -> B + Clone + $send + 'static,
+				F: $fns::FnMut(B, Either<Self::Output, B>) -> B + Clone + $send + 'static,
 				B: $send + 'static,
 				Self: Sized,
 			{
@@ -130,15 +129,15 @@ macro_rules! pipe {
 				<S::Pipe as $pipe<B>>::Task: Clone + $send + 'static,
 				S::ReduceA: 'static,
 				S::ReduceC: Clone,
-				S::Output: $send + 'static,
-				Self: $pipe<Source, Item = (A, B)> + Sized,
+				S::Done: $send + 'static,
+				Self: $pipe<Input, Output = (A, B)> + Sized,
 			{
 				$assert_sink(GroupBy::new(self, sink))
 			}
 
 			fn histogram(self) -> Histogram<Self>
 			where
-				Self::Item: Hash + Ord + $send + 'static,
+				Self::Output: Hash + Ord + $send + 'static,
 				Self: Sized,
 			{
 				$assert_sink(Histogram::new(self))
@@ -153,7 +152,7 @@ macro_rules! pipe {
 
 			fn sum<B>(self) -> Sum<Self, B>
 			where
-				B: iter::Sum<Self::Item> + iter::Sum<B> + $send + 'static,
+				B: iter::Sum<Self::Output> + iter::Sum<B> + $send + 'static,
 				Self: Sized,
 			{
 				$assert_sink(Sum::new(self))
@@ -161,8 +160,8 @@ macro_rules! pipe {
 
 			fn combine<F>(self, f: F) -> Combine<Self, F>
 			where
-				F: $fns::FnMut(Self::Item, Self::Item) -> Self::Item + Clone + $send + 'static,
-				Self::Item: $send + 'static,
+				F: $fns::FnMut(Self::Output, Self::Output) -> Self::Output + Clone + $send + 'static,
+				Self::Output: $send + 'static,
 				Self: Sized,
 			{
 				$assert_sink(Combine::new(self, f))
@@ -170,7 +169,7 @@ macro_rules! pipe {
 
 			fn max(self) -> Max<Self>
 			where
-				Self::Item: Ord + $send + 'static,
+				Self::Output: Ord + $send + 'static,
 				Self: Sized,
 			{
 				$assert_sink(Max::new(self))
@@ -178,8 +177,8 @@ macro_rules! pipe {
 
 			fn max_by<F>(self, f: F) -> MaxBy<Self, F>
 			where
-				F: $fns::FnMut(&Self::Item, &Self::Item) -> Ordering + Clone + $send + 'static,
-				Self::Item: $send + 'static,
+				F: $fns::FnMut(&Self::Output, &Self::Output) -> Ordering + Clone + $send + 'static,
+				Self::Output: $send + 'static,
 				Self: Sized,
 			{
 				$assert_sink(MaxBy::new(self, f))
@@ -187,9 +186,9 @@ macro_rules! pipe {
 
 			fn max_by_key<F, B>(self, f: F) -> MaxByKey<Self, F>
 			where
-				F: $fns::FnMut(&Self::Item) -> B + Clone + $send + 'static,
+				F: $fns::FnMut(&Self::Output) -> B + Clone + $send + 'static,
 				B: Ord + 'static,
-				Self::Item: $send + 'static,
+				Self::Output: $send + 'static,
 				Self: Sized,
 			{
 				$assert_sink(MaxByKey::new(self, f))
@@ -197,7 +196,7 @@ macro_rules! pipe {
 
 			fn min(self) -> Min<Self>
 			where
-				Self::Item: Ord + $send + 'static,
+				Self::Output: Ord + $send + 'static,
 				Self: Sized,
 			{
 				$assert_sink(Min::new(self))
@@ -205,8 +204,8 @@ macro_rules! pipe {
 
 			fn min_by<F>(self, f: F) -> MinBy<Self, F>
 			where
-				F: $fns::FnMut(&Self::Item, &Self::Item) -> Ordering + Clone + $send + 'static,
-				Self::Item: $send + 'static,
+				F: $fns::FnMut(&Self::Output, &Self::Output) -> Ordering + Clone + $send + 'static,
+				Self::Output: $send + 'static,
 				Self: Sized,
 			{
 				$assert_sink(MinBy::new(self, f))
@@ -214,9 +213,9 @@ macro_rules! pipe {
 
 			fn min_by_key<F, B>(self, f: F) -> MinByKey<Self, F>
 			where
-				F: $fns::FnMut(&Self::Item) -> B + Clone + $send + 'static,
+				F: $fns::FnMut(&Self::Output) -> B + Clone + $send + 'static,
 				B: Ord + 'static,
-				Self::Item: $send + 'static,
+				Self::Output: $send + 'static,
 				Self: Sized,
 			{
 				$assert_sink(MinByKey::new(self, f))
@@ -224,7 +223,7 @@ macro_rules! pipe {
 
 			fn most_frequent(self, n: usize, probability: f64, tolerance: f64) -> MostFrequent<Self>
 			where
-				Self::Item: Hash + Eq + Clone + $send + 'static,
+				Self::Output: Hash + Eq + Clone + $send + 'static,
 				Self: Sized,
 			{
 				$assert_sink(MostFrequent::new(self, n, probability, tolerance))
@@ -234,7 +233,7 @@ macro_rules! pipe {
 				self, n: usize, probability: f64, tolerance: f64, error_rate: f64,
 			) -> MostDistinct<Self>
 			where
-				Self: $pipe<Source, Item = (A, B)> + Sized,
+				Self: $pipe<Input, Output = (A, B)> + Sized,
 				A: Hash + Eq + Clone + $send + 'static,
 				B: Hash + 'static,
 			{
@@ -249,7 +248,7 @@ macro_rules! pipe {
 
 			fn sample_unstable(self, samples: usize) -> SampleUnstable<Self>
 			where
-				Self::Item: $send + 'static,
+				Self::Output: $send + 'static,
 				Self: Sized,
 			{
 				$assert_sink(SampleUnstable::new(self, samples))
@@ -257,7 +256,7 @@ macro_rules! pipe {
 
 			fn all<F>(self, f: F) -> All<Self, F>
 			where
-				F: $fns::FnMut(Self::Item) -> bool + Clone + $send + 'static,
+				F: $fns::FnMut(Self::Output) -> bool + Clone + $send + 'static,
 				Self: Sized,
 			{
 				$assert_sink(All::new(self, f))
@@ -265,7 +264,7 @@ macro_rules! pipe {
 
 			fn any<F>(self, f: F) -> Any<Self, F>
 			where
-				F: $fns::FnMut(Self::Item) -> bool + Clone + $send + 'static,
+				F: $fns::FnMut(Self::Output) -> bool + Clone + $send + 'static,
 				Self: Sized,
 			{
 				$assert_sink(Any::new(self, f))
@@ -273,7 +272,7 @@ macro_rules! pipe {
 
 			fn collect<B>(self) -> Collect<Self, B>
 			where
-				B: $from_sink<Self::Item>,
+				B: $from_sink<Self::Output>,
 				Self: Sized,
 			{
 				$assert_sink(Collect::new(self))
@@ -281,7 +280,7 @@ macro_rules! pipe {
 		}
 
 		#[inline(always)]
-		pub(crate) fn $assert_pipe<T, I: $pipe<Source, Item = T>, Source>(i: I) -> I {
+		pub(crate) fn $assert_pipe<T, I: $pipe<Input, Output = T>, Input>(i: I) -> I {
 			i
 		}
 	};

--- a/amadeus-core/src/par_sink/any.rs
+++ b/amadeus-core/src/par_sink/any.rs
@@ -5,47 +5,47 @@ use pin_project::pin_project;
 use serde::{Deserialize, Serialize};
 use serde_closure::traits::FnMut;
 use std::{
-	future::Future, marker::PhantomData, pin::Pin, task::{Context, Poll}
+	marker::PhantomData, pin::Pin, task::{Context, Poll}
 };
 
 use super::{
-	DistributedPipe, DistributedSink, ParallelPipe, ParallelSink, Reducer, ReducerAsync, ReducerProcessSend, ReducerSend
+	DistributedPipe, DistributedSink, ParallelPipe, ParallelSink, Reducer, ReducerProcessSend, ReducerSend
 };
 use crate::{pipe::Sink, pool::ProcessSend};
 
 #[derive(new)]
 #[must_use]
-pub struct Any<I, F> {
-	i: I,
+pub struct Any<P, F> {
+	pipe: P,
 	f: F,
 }
 
-impl<I: ParallelPipe<Source>, Source, F> ParallelSink<Source> for Any<I, F>
+impl<P: ParallelPipe<Input>, Input, F> ParallelSink<Input> for Any<P, F>
 where
-	F: FnMut<(I::Item,), Output = bool> + Clone + Send + 'static,
+	F: FnMut<(P::Output,), Output = bool> + Clone + Send + 'static,
 {
-	type Output = bool;
-	type Pipe = I;
-	type ReduceA = AnyReducer<I::Item, F>;
+	type Done = bool;
+	type Pipe = P;
+	type ReduceA = AnyReducer<P::Output, F>;
 	type ReduceC = BoolOrReducer;
 
 	fn reducers(self) -> (Self::Pipe, Self::ReduceA, Self::ReduceC) {
-		(self.i, AnyReducer(self.f, PhantomData), BoolOrReducer)
+		(self.pipe, AnyReducer(self.f, PhantomData), BoolOrReducer)
 	}
 }
-impl<I: DistributedPipe<Source>, Source, F> DistributedSink<Source> for Any<I, F>
+impl<P: DistributedPipe<Input>, Input, F> DistributedSink<Input> for Any<P, F>
 where
-	F: FnMut<(I::Item,), Output = bool> + Clone + ProcessSend + 'static,
+	F: FnMut<(P::Output,), Output = bool> + Clone + ProcessSend + 'static,
 {
-	type Output = bool;
-	type Pipe = I;
-	type ReduceA = AnyReducer<I::Item, F>;
+	type Done = bool;
+	type Pipe = P;
+	type ReduceA = AnyReducer<P::Output, F>;
 	type ReduceB = BoolOrReducer;
 	type ReduceC = BoolOrReducer;
 
 	fn reducers(self) -> (Self::Pipe, Self::ReduceA, Self::ReduceB, Self::ReduceC) {
 		(
-			self.i,
+			self.pipe,
 			AnyReducer(self.f, PhantomData),
 			BoolOrReducer,
 			BoolOrReducer,
@@ -59,30 +59,30 @@ where
 	bound(serialize = "F: Serialize"),
 	bound(deserialize = "F: Deserialize<'de>")
 )]
-pub struct AnyReducer<A, F>(F, PhantomData<fn() -> A>);
+pub struct AnyReducer<Item, F>(F, PhantomData<fn() -> Item>);
 
-impl<A, F> Reducer<A> for AnyReducer<A, F>
+impl<Item, F> Reducer<Item> for AnyReducer<Item, F>
 where
-	F: FnMut<(A,), Output = bool>,
+	F: FnMut<(Item,), Output = bool>,
 {
-	type Output = bool;
-	type Async = AnyReducerAsync<A, F>;
+	type Done = bool;
+	type Async = AnyReducerAsync<Item, F>;
 
 	fn into_async(self) -> Self::Async {
 		AnyReducerAsync(self.0, true, PhantomData)
 	}
 }
-impl<A, F> ReducerProcessSend<A> for AnyReducer<A, F>
+impl<Item, F> ReducerProcessSend<Item> for AnyReducer<Item, F>
 where
-	F: FnMut<(A,), Output = bool>,
+	F: FnMut<(Item,), Output = bool>,
 {
-	type Output = bool;
+	type Done = bool;
 }
-impl<A, F> ReducerSend<A> for AnyReducer<A, F>
+impl<Item, F> ReducerSend<Item> for AnyReducer<Item, F>
 where
-	F: FnMut<(A,), Output = bool>,
+	F: FnMut<(Item,), Output = bool>,
 {
-	type Output = bool;
+	type Done = bool;
 }
 
 #[pin_project]
@@ -91,16 +91,18 @@ where
 	bound(serialize = "F: Serialize"),
 	bound(deserialize = "F: Deserialize<'de>")
 )]
-pub struct AnyReducerAsync<A, F>(F, bool, PhantomData<fn() -> A>);
+pub struct AnyReducerAsync<Item, F>(F, bool, PhantomData<fn() -> Item>);
 
-impl<A, F> Sink<A> for AnyReducerAsync<A, F>
+impl<Item, F> Sink<Item> for AnyReducerAsync<Item, F>
 where
-	F: FnMut<(A,), Output = bool>,
+	F: FnMut<(Item,), Output = bool>,
 {
+	type Done = bool;
+
 	#[inline(always)]
-	fn poll_pipe(
-		self: Pin<&mut Self>, cx: &mut Context, mut stream: Pin<&mut impl Stream<Item = A>>,
-	) -> Poll<()> {
+	fn poll_forward(
+		self: Pin<&mut Self>, cx: &mut Context, mut stream: Pin<&mut impl Stream<Item = Item>>,
+	) -> Poll<Self::Done> {
 		let self_ = self.project();
 		while *self_.1 {
 			if let Some(item) = ready!(stream.as_mut().poll_next(cx)) {
@@ -109,17 +111,7 @@ where
 				break;
 			}
 		}
-		Poll::Ready(())
-	}
-}
-impl<A, F> ReducerAsync<A> for AnyReducerAsync<A, F>
-where
-	F: FnMut<(A,), Output = bool>,
-{
-	type Output = bool;
-
-	fn output<'a>(self: Pin<&'a mut Self>) -> Pin<Box<dyn Future<Output = Self::Output> + 'a>> {
-		Box::pin(async move { !self.1 })
+		Poll::Ready(!*self_.1)
 	}
 }
 
@@ -127,7 +119,7 @@ where
 pub struct BoolOrReducer;
 
 impl Reducer<bool> for BoolOrReducer {
-	type Output = bool;
+	type Done = bool;
 	type Async = BoolOrReducerAsync;
 
 	fn into_async(self) -> Self::Async {
@@ -135,10 +127,10 @@ impl Reducer<bool> for BoolOrReducer {
 	}
 }
 impl ReducerProcessSend<bool> for BoolOrReducer {
-	type Output = bool;
+	type Done = bool;
 }
 impl ReducerSend<bool> for BoolOrReducer {
-	type Output = bool;
+	type Done = bool;
 }
 
 #[pin_project]
@@ -146,10 +138,12 @@ impl ReducerSend<bool> for BoolOrReducer {
 pub struct BoolOrReducerAsync(bool);
 
 impl Sink<bool> for BoolOrReducerAsync {
+	type Done = bool;
+
 	#[inline(always)]
-	fn poll_pipe(
+	fn poll_forward(
 		mut self: Pin<&mut Self>, cx: &mut Context, mut stream: Pin<&mut impl Stream<Item = bool>>,
-	) -> Poll<()> {
+	) -> Poll<Self::Done> {
 		while self.0 {
 			if let Some(item) = ready!(stream.as_mut().poll_next(cx)) {
 				self.0 = self.0 && !item;
@@ -157,13 +151,6 @@ impl Sink<bool> for BoolOrReducerAsync {
 				break;
 			}
 		}
-		Poll::Ready(())
-	}
-}
-impl ReducerAsync<bool> for BoolOrReducerAsync {
-	type Output = bool;
-
-	fn output<'a>(self: Pin<&'a mut Self>) -> Pin<Box<dyn Future<Output = Self::Output> + 'a>> {
-		Box::pin(async move { !self.0 })
+		Poll::Ready(!self.0)
 	}
 }

--- a/amadeus-core/src/par_sink/count.rs
+++ b/amadeus-core/src/par_sink/count.rs
@@ -7,26 +7,32 @@ use super::{
 
 #[derive(new)]
 #[must_use]
-pub struct Count<I> {
-	i: I,
+pub struct Count<P> {
+	pipe: P,
 }
 
 impl_par_dist! {
-	impl<I: ParallelPipe<Source>, Source> ParallelSink<Source> for Count<I> {
-		folder_par_sink!(CountFolder, SumFolder<usize>, self, CountFolder::new(), SumFolder::new());
+	impl<P: ParallelPipe<Input>, Input> ParallelSink<Input> for Count<P> {
+		folder_par_sink!(
+			CountFolder,
+			SumFolder<usize>,
+			self,
+			CountFolder::new(),
+			SumFolder::new()
+		);
 	}
 }
 
 #[derive(Clone, Serialize, Deserialize, new)]
 pub struct CountFolder;
 
-impl<A> FolderSync<A> for CountFolder {
-	type Output = usize;
+impl<Item> FolderSync<Item> for CountFolder {
+	type Done = usize;
 
-	fn zero(&mut self) -> Self::Output {
+	fn zero(&mut self) -> Self::Done {
 		0
 	}
-	fn push(&mut self, state: &mut Self::Output, _item: A) {
+	fn push(&mut self, state: &mut Self::Done, _item: Item) {
 		*state += 1;
 	}
 }

--- a/amadeus-core/src/par_sink/for_each.rs
+++ b/amadeus-core/src/par_sink/for_each.rs
@@ -5,51 +5,51 @@ use pin_project::pin_project;
 use serde::{Deserialize, Serialize};
 use serde_closure::traits::FnMut;
 use std::{
-	future::Future, marker::PhantomData, pin::Pin, task::{Context, Poll}
+	marker::PhantomData, pin::Pin, task::{Context, Poll}
 };
 
 use super::{
-	DistributedPipe, DistributedSink, ParallelPipe, ParallelSink, PushReducer, Reducer, ReducerAsync, ReducerProcessSend, ReducerSend
+	DistributedPipe, DistributedSink, ParallelPipe, ParallelSink, PushReducer, Reducer, ReducerProcessSend, ReducerSend
 };
 use crate::{pipe::Sink, pool::ProcessSend};
 
 #[derive(new)]
 #[must_use]
-pub struct ForEach<I, F> {
-	i: I,
+pub struct ForEach<P, F> {
+	pipe: P,
 	f: F,
 }
 
-impl<I: ParallelPipe<Source>, Source, F> ParallelSink<Source> for ForEach<I, F>
+impl<P: ParallelPipe<Input>, Input, F> ParallelSink<Input> for ForEach<P, F>
 where
-	F: FnMut<(I::Item,), Output = ()> + Clone + Send + 'static,
+	F: FnMut<(P::Output,), Output = ()> + Clone + Send + 'static,
 {
-	type Output = ();
-	type Pipe = I;
-	type ReduceA = ForEachReducer<I::Item, F>;
+	type Done = ();
+	type Pipe = P;
+	type ReduceA = ForEachReducer<P::Output, F>;
 	type ReduceC = PushReducer<()>;
 
 	fn reducers(self) -> (Self::Pipe, Self::ReduceA, Self::ReduceC) {
 		(
-			self.i,
+			self.pipe,
 			ForEachReducer(self.f, PhantomData),
 			PushReducer::new(),
 		)
 	}
 }
-impl<I: DistributedPipe<Source>, Source, F> DistributedSink<Source> for ForEach<I, F>
+impl<P: DistributedPipe<Input>, Input, F> DistributedSink<Input> for ForEach<P, F>
 where
-	F: FnMut<(I::Item,), Output = ()> + Clone + ProcessSend + 'static,
+	F: FnMut<(P::Output,), Output = ()> + Clone + ProcessSend + 'static,
 {
-	type Output = ();
-	type Pipe = I;
-	type ReduceA = ForEachReducer<I::Item, F>;
+	type Done = ();
+	type Pipe = P;
+	type ReduceA = ForEachReducer<P::Output, F>;
 	type ReduceB = PushReducer<()>;
 	type ReduceC = PushReducer<()>;
 
 	fn reducers(self) -> (Self::Pipe, Self::ReduceA, Self::ReduceB, Self::ReduceC) {
 		(
-			self.i,
+			self.pipe,
 			ForEachReducer(self.f, PhantomData),
 			PushReducer::new(),
 			PushReducer::new(),
@@ -64,54 +64,46 @@ where
 	bound(serialize = "F: Serialize"),
 	bound(deserialize = "F: Deserialize<'de>")
 )]
-pub struct ForEachReducer<A, F>(F, PhantomData<fn() -> A>);
+pub struct ForEachReducer<Item, F>(F, PhantomData<fn() -> Item>);
 
-impl<A, F> Reducer<A> for ForEachReducer<A, F>
+impl<Item, F> Reducer<Item> for ForEachReducer<Item, F>
 where
-	F: FnMut<(A,), Output = ()> + Clone,
+	F: FnMut<(Item,), Output = ()>,
 {
-	type Output = ();
+	type Done = ();
 	type Async = Self;
 
 	fn into_async(self) -> Self::Async {
 		self
 	}
 }
-impl<A, F> ReducerProcessSend<A> for ForEachReducer<A, F>
+impl<Item, F> ReducerProcessSend<Item> for ForEachReducer<Item, F>
 where
-	F: FnMut<(A,), Output = ()> + Clone,
+	F: FnMut<(Item,), Output = ()>,
 {
-	type Output = ();
+	type Done = ();
 }
-impl<A, F> ReducerSend<A> for ForEachReducer<A, F>
+impl<Item, F> ReducerSend<Item> for ForEachReducer<Item, F>
 where
-	F: FnMut<(A,), Output = ()> + Clone,
+	F: FnMut<(Item,), Output = ()>,
 {
-	type Output = ();
+	type Done = ();
 }
 
-impl<A, F> Sink<A> for ForEachReducer<A, F>
+impl<Item, F> Sink<Item> for ForEachReducer<Item, F>
 where
-	F: FnMut<(A,), Output = ()> + Clone,
+	F: FnMut<(Item,), Output = ()>,
 {
+	type Done = ();
+
 	#[inline(always)]
-	fn poll_pipe(
-		self: Pin<&mut Self>, cx: &mut Context, mut stream: Pin<&mut impl Stream<Item = A>>,
-	) -> Poll<()> {
+	fn poll_forward(
+		self: Pin<&mut Self>, cx: &mut Context, mut stream: Pin<&mut impl Stream<Item = Item>>,
+	) -> Poll<Self::Done> {
 		let self_ = self.project();
 		while let Some(item) = ready!(stream.as_mut().poll_next(cx)) {
 			self_.0.call_mut((item,));
 		}
 		Poll::Ready(())
-	}
-}
-impl<A, F> ReducerAsync<A> for ForEachReducer<A, F>
-where
-	F: FnMut<(A,), Output = ()> + Clone,
-{
-	type Output = ();
-
-	fn output<'a>(self: Pin<&'a mut Self>) -> Pin<Box<dyn Future<Output = Self::Output> + 'a>> {
-		Box::pin(async move {})
 	}
 }

--- a/amadeus-core/src/par_sink/group_by.rs
+++ b/amadeus-core/src/par_sink/group_by.rs
@@ -2,15 +2,16 @@
 
 use derive_new::new;
 use educe::Educe;
-use futures::{future::join_all, pin_mut, ready, stream, Stream, StreamExt};
+use futures::{pin_mut, ready, stream, Stream, StreamExt};
 use pin_project::pin_project;
 use serde::{Deserialize, Serialize};
 use std::{
-	collections::HashMap, future::Future, hash::Hash, marker::PhantomData, mem, pin::Pin, task::{Context, Poll}
+	collections::HashMap, hash::Hash, marker::PhantomData, mem, pin::Pin, task::{Context, Poll}
 };
+use sum::Sum2;
 
 use super::{
-	DistributedPipe, DistributedSink, ParallelPipe, ParallelSink, PipeTask, Reducer, ReducerAsync, ReducerProcessSend, ReducerSend
+	DistributedPipe, DistributedSink, ParallelPipe, ParallelSink, PipeTask, Reducer, ReducerProcessSend, ReducerSend
 };
 use crate::{
 	pipe::{Pipe, Sink, StreamExt as _}, pool::ProcessSend
@@ -23,22 +24,22 @@ pub struct GroupBy<A, B> {
 	b: B,
 }
 
-impl<A: ParallelPipe<Source, Item = (T, U)>, B: ParallelSink<U>, Source, T, U> ParallelSink<Source>
+impl<A: ParallelPipe<Input, Output = (T, U)>, B: ParallelSink<U>, Input, T, U> ParallelSink<Input>
 	for GroupBy<A, B>
 where
 	T: Eq + Hash + Send + 'static,
 	<B::Pipe as ParallelPipe<U>>::Task: Clone + Send + 'static,
 	B::ReduceA: Clone + Send + 'static,
 	B::ReduceC: Clone,
-	B::Output: Send + 'static,
+	B::Done: Send + 'static,
 {
-	type Output = HashMap<T, B::Output>;
+	type Done = HashMap<T, B::Done>;
 	type Pipe = A;
 	type ReduceA = GroupByReducerA<<B::Pipe as ParallelPipe<U>>::Task, B::ReduceA, T, U>;
 	type ReduceC = GroupByReducerB<
 		B::ReduceC,
 		T,
-		<B::ReduceA as ReducerSend<<B::Pipe as ParallelPipe<U>>::Item>>::Output,
+		<B::ReduceA as ReducerSend<<B::Pipe as ParallelPipe<U>>::Output>>::Done,
 	>;
 
 	fn reducers(self) -> (Self::Pipe, Self::ReduceA, Self::ReduceC) {
@@ -51,30 +52,30 @@ where
 	}
 }
 
-impl<A: DistributedPipe<Source, Item = (T, U)>, B: DistributedSink<U>, Source, T, U>
-	DistributedSink<Source> for GroupBy<A, B>
+impl<A: DistributedPipe<Input, Output = (T, U)>, B: DistributedSink<U>, Input, T, U>
+	DistributedSink<Input> for GroupBy<A, B>
 where
 	T: Eq + Hash + ProcessSend + 'static,
 	<B::Pipe as DistributedPipe<U>>::Task: Clone + ProcessSend + 'static,
 	B::ReduceA: Clone + ProcessSend + 'static,
 	B::ReduceB: Clone,
 	B::ReduceC: Clone,
-	B::Output: ProcessSend + 'static,
+	B::Done: ProcessSend + 'static,
 {
-	type Output = HashMap<T, B::Output>;
+	type Done = HashMap<T, B::Done>;
 	type Pipe = A;
 	type ReduceA = GroupByReducerA<<B::Pipe as DistributedPipe<U>>::Task, B::ReduceA, T, U>;
 	type ReduceB = GroupByReducerB<
 		B::ReduceB,
 		T,
-		<B::ReduceA as ReducerSend<<B::Pipe as DistributedPipe<U>>::Item>>::Output,
+		<B::ReduceA as ReducerSend<<B::Pipe as DistributedPipe<U>>::Output>>::Done,
 	>;
 	type ReduceC = GroupByReducerB<
 		B::ReduceC,
 		T,
 		<B::ReduceB as ReducerProcessSend<
-			<B::ReduceA as Reducer<<B::Pipe as DistributedPipe<U>>::Item>>::Output,
-		>>::Output,
+			<B::ReduceA as Reducer<<B::Pipe as DistributedPipe<U>>::Output>>::Done,
+		>>::Done,
 	>;
 
 	fn reducers(self) -> (Self::Pipe, Self::ReduceA, Self::ReduceB, Self::ReduceC) {
@@ -99,11 +100,11 @@ pub struct GroupByReducerA<P, R, T, U>(P, R, PhantomData<fn() -> (R, T, U)>);
 impl<P, R, T, U> Reducer<(T, U)> for GroupByReducerA<P, R, T, U>
 where
 	P: PipeTask<U>,
-	R: Reducer<P::Item> + Clone,
+	R: Reducer<P::Output> + Clone,
 	T: Eq + Hash,
 {
-	type Output = HashMap<T, R::Output>;
-	type Async = GroupByReducerAAsync<P::Async, R, R::Async, T, U>;
+	type Done = HashMap<T, R::Done>;
+	type Async = GroupByReducerAAsync<P::Async, R, T, U>;
 
 	fn into_async(self) -> Self::Async {
 		GroupByReducerAAsync::new(self.0.into_async(), self.1)
@@ -112,116 +113,130 @@ where
 impl<P, R, T, U> ReducerProcessSend<(T, U)> for GroupByReducerA<P, R, T, U>
 where
 	P: PipeTask<U>,
-	R: Reducer<P::Item> + Clone,
+	R: Reducer<P::Output> + Clone,
 	T: Eq + Hash + ProcessSend + 'static,
-	R::Output: ProcessSend + 'static,
+	R::Done: ProcessSend + 'static,
 {
-	type Output = HashMap<T, R::Output>;
+	type Done = HashMap<T, R::Done>;
 }
 impl<P, R, T, U> ReducerSend<(T, U)> for GroupByReducerA<P, R, T, U>
 where
 	P: PipeTask<U>,
-	R: Reducer<P::Item> + Clone,
+	R: Reducer<P::Output> + Clone,
 	T: Eq + Hash + Send + 'static,
-	R::Output: Send + 'static,
+	R::Done: Send + 'static,
 {
-	type Output = HashMap<T, R::Output>;
+	type Done = HashMap<T, R::Done>;
 }
 
 #[pin_project]
 #[derive(new)]
-pub struct GroupByReducerAAsync<P, R, RA, T, U> {
+pub struct GroupByReducerAAsync<P, R, T, U>
+where
+	P: Pipe<U>,
+	R: Reducer<P::Output>,
+{
 	#[pin]
 	pipe: P,
 	factory: R,
 	#[new(default)]
-	pending: Option<Option<(T, Option<U>, Option<Pin<Box<RA>>>)>>,
+	pending: Option<Sum2<(T, Option<U>, Option<Pin<Box<R::Async>>>), Vec<Option<R::Done>>>>,
 	#[new(default)]
-	map: HashMap<T, Pin<Box<RA>>>,
+	map: HashMap<T, Pin<Box<R::Async>>>,
 	marker: PhantomData<fn() -> (R, U)>,
 }
 
-impl<P, R, T, U> Sink<(T, U)> for GroupByReducerAAsync<P, R, R::Async, T, U>
+impl<P, R, T, U> Sink<(T, U)> for GroupByReducerAAsync<P, R, T, U>
 where
 	P: Pipe<U>,
-	R: Reducer<P::Item> + Clone,
+	R: Reducer<P::Output> + Clone,
 	T: Eq + Hash,
 {
+	type Done = HashMap<T, R::Done>;
+
 	#[inline(always)]
-	fn poll_pipe(
+	fn poll_forward(
 		self: Pin<&mut Self>, cx: &mut Context, mut stream: Pin<&mut impl Stream<Item = (T, U)>>,
-	) -> Poll<()> {
+	) -> Poll<Self::Done> {
 		let mut self_ = self.project();
 		loop {
 			if !self_.pending.is_some() {
-				*self_.pending = Some(ready!(stream.as_mut().poll_next(cx)).map(|(k, u)| {
-					let r = if !self_.map.contains_key(&k) {
-						Some(Box::pin(self_.factory.clone().into_async()))
-					} else {
-						None
-					};
-					(k, Some(u), r)
-				}));
+				*self_.pending = Some(
+					ready!(stream.as_mut().poll_next(cx))
+						.map(|(k, u)| {
+							let r = if !self_.map.contains_key(&k) {
+								Some(Box::pin(self_.factory.clone().into_async()))
+							} else {
+								None
+							};
+							(k, Some(u), r)
+						})
+						.map_or_else(
+							|| Sum2::B((0..self_.map.len()).map(|_| None).collect()),
+							Sum2::A,
+						),
+				);
 			}
-			if let Some((k, u, r)) = self_.pending.as_mut().unwrap() {
-				let waker = cx.waker();
-				let stream = stream::poll_fn(|cx| {
-					if let Some(u) = u.take() {
-						Poll::Ready(Some(u))
-					} else {
-						let waker_ = cx.waker();
-						if !waker.will_wake(waker_) {
-							waker_.wake_by_ref();
+			match self_.pending.as_mut().unwrap() {
+				Sum2::A((k, u, r)) => {
+					let waker = cx.waker();
+					let stream = stream::poll_fn(|cx| {
+						if let Some(u) = u.take() {
+							Poll::Ready(Some(u))
+						} else {
+							let waker_ = cx.waker();
+							if !waker.will_wake(waker_) {
+								waker_.wake_by_ref();
+							}
+							Poll::Pending
 						}
-						Poll::Pending
-					}
-				})
-				.fuse()
-				.pipe(self_.pipe.as_mut());
-				pin_mut!(stream);
-				let map = &mut *self_.map;
-				let r_ = r.as_mut().unwrap_or_else(|| map.get_mut(&k).unwrap());
-				if r_.as_mut().poll_pipe(cx, stream).is_ready() {
-					let _ = u.take();
-				}
-				if u.is_some() {
-					return Poll::Pending;
-				}
-				let (k, _u, r) = self_.pending.take().unwrap().unwrap();
-				if let Some(r) = r {
-					let _ = self_.map.insert(k, r);
-				}
-			} else {
-				for r in self_.map.values_mut() {
-					let stream = stream::empty();
+					})
+					.fuse()
+					.pipe(self_.pipe.as_mut());
 					pin_mut!(stream);
-					ready!(r.as_mut().poll_pipe(cx, stream));
+					let map = &mut *self_.map;
+					let r_ = r.as_mut().unwrap_or_else(|| map.get_mut(&k).unwrap());
+					if r_.as_mut().poll_forward(cx, stream).is_ready() {
+						let _ = u.take();
+					}
+					if u.is_some() {
+						return Poll::Pending;
+					}
+					let (k, _u, r) = self_.pending.take().unwrap().a().unwrap();
+					if let Some(r) = r {
+						let _ = self_.map.insert(k, r);
+					}
 				}
-				return Poll::Ready(());
+				Sum2::B(done) => {
+					let mut done_ = true;
+					self_
+						.map
+						.values_mut()
+						.zip(done.iter_mut())
+						.for_each(|(r, done)| {
+							if done.is_none() {
+								let stream = stream::empty();
+								pin_mut!(stream);
+								if let Poll::Ready(done_) = r.as_mut().poll_forward(cx, stream) {
+									*done = Some(done_);
+								} else {
+									done_ = false;
+								}
+							}
+						});
+					if !done_ {
+						return Poll::Pending;
+					}
+					let ret = self_
+						.map
+						.drain()
+						.zip(done.iter_mut())
+						.map(|((k, _), v)| (k, v.take().unwrap()))
+						.collect();
+					return Poll::Ready(ret);
+				}
 			}
 		}
-	}
-}
-impl<P, R, T, U> ReducerAsync<(T, U)> for GroupByReducerAAsync<P, R, R::Async, T, U>
-where
-	P: Pipe<U>,
-	R: Reducer<P::Item> + Clone,
-	T: Eq + Hash,
-{
-	type Output = HashMap<T, R::Output>;
-
-	fn output<'a>(self: Pin<&'a mut Self>) -> Pin<Box<dyn Future<Output = Self::Output> + 'a>> {
-		Box::pin(async move {
-			let self_ = self.project();
-			join_all(
-				mem::take(self_.map)
-					.into_iter()
-					.map(|(k, mut v)| async move { (k, v.as_mut().output().await) }),
-			)
-			.await
-			.into_iter()
-			.collect()
-		})
 	}
 }
 
@@ -238,8 +253,8 @@ where
 	R: Reducer<U> + Clone,
 	T: Eq + Hash,
 {
-	type Output = HashMap<T, R::Output>;
-	type Async = GroupByReducerBAsync<R, R::Async, T, U>;
+	type Done = HashMap<T, R::Done>;
+	type Async = GroupByReducerBAsync<R, T, U>;
 
 	fn into_async(self) -> Self::Async {
 		GroupByReducerBAsync::new(self.0)
@@ -249,117 +264,131 @@ impl<R, T, U> ReducerProcessSend<HashMap<T, U>> for GroupByReducerB<R, T, U>
 where
 	R: Reducer<U> + Clone,
 	T: Eq + Hash + ProcessSend + 'static,
-	R::Output: ProcessSend + 'static,
+	R::Done: ProcessSend + 'static,
 {
-	type Output = HashMap<T, R::Output>;
+	type Done = HashMap<T, R::Done>;
 }
 impl<R, T, U> ReducerSend<HashMap<T, U>> for GroupByReducerB<R, T, U>
 where
 	R: Reducer<U> + Clone,
 	T: Eq + Hash + Send + 'static,
-	R::Output: Send + 'static,
+	R::Done: Send + 'static,
 {
-	type Output = HashMap<T, R::Output>;
+	type Done = HashMap<T, R::Done>;
 }
 
 #[pin_project]
 #[derive(new)]
-pub struct GroupByReducerBAsync<R, RA, T, U> {
+pub struct GroupByReducerBAsync<R, T, U>
+where
+	R: Reducer<U>,
+{
 	f: R,
 	#[new(default)]
-	pending: Option<Option<HashMap<T, (U, Option<Pin<Box<RA>>>)>>>,
+	pending: Option<Sum2<HashMap<T, (U, Option<Pin<Box<R::Async>>>)>, Vec<Option<R::Done>>>>,
 	#[new(default)]
-	map: HashMap<T, Pin<Box<RA>>>,
+	map: HashMap<T, Pin<Box<R::Async>>>,
 	marker: PhantomData<fn() -> (T, U)>,
 }
 
-impl<R, T, U> Sink<HashMap<T, U>> for GroupByReducerBAsync<R, R::Async, T, U>
+impl<R, T, U> Sink<HashMap<T, U>> for GroupByReducerBAsync<R, T, U>
 where
 	R: Reducer<U> + Clone,
 	T: Eq + Hash,
 {
+	type Done = HashMap<T, R::Done>;
+
 	#[inline(always)]
-	fn poll_pipe(
+	fn poll_forward(
 		self: Pin<&mut Self>, cx: &mut Context,
 		mut stream: Pin<&mut impl Stream<Item = HashMap<T, U>>>,
-	) -> Poll<()> {
+	) -> Poll<Self::Done> {
 		let self_ = self.project();
 		loop {
 			if self_.pending.is_none() {
-				*self_.pending = Some(ready!(stream.as_mut().poll_next(cx)).map(|item| {
-					item.into_iter()
-						.map(|(k, v)| {
-							let r = if !self_.map.contains_key(&k) {
-								Some(Box::pin(self_.f.clone().into_async()))
-							} else {
-								None
-							};
-							(k, (v, r))
+				*self_.pending = Some(
+					ready!(stream.as_mut().poll_next(cx))
+						.map(|item| {
+							item.into_iter()
+								.map(|(k, v)| {
+									let r = if !self_.map.contains_key(&k) {
+										Some(Box::pin(self_.f.clone().into_async()))
+									} else {
+										None
+									};
+									(k, (v, r))
+								})
+								.collect()
 						})
-						.collect()
-				}));
+						.map_or_else(
+							|| Sum2::B((0..self_.map.len()).map(|_| None).collect()),
+							Sum2::A,
+						),
+				);
 			}
-			if let Some(pending) = self_.pending.as_mut().unwrap() {
-				while let Some((k, (v, mut r))) = pop(pending) {
-					let mut v = Some(v);
-					let waker = cx.waker();
-					let stream = stream::poll_fn(|cx| {
-						if let Some(v) = v.take() {
-							Poll::Ready(Some(v))
-						} else {
-							let waker_ = cx.waker();
-							if !waker.will_wake(waker_) {
-								waker_.wake_by_ref();
+			match self_.pending.as_mut().unwrap() {
+				Sum2::A(pending) => {
+					while let Some((k, (v, mut r))) = pop(pending) {
+						let mut v = Some(v);
+						let waker = cx.waker();
+						let stream = stream::poll_fn(|cx| {
+							if let Some(v) = v.take() {
+								Poll::Ready(Some(v))
+							} else {
+								let waker_ = cx.waker();
+								if !waker.will_wake(waker_) {
+									waker_.wake_by_ref();
+								}
+								Poll::Pending
 							}
-							Poll::Pending
+						})
+						.fuse();
+						pin_mut!(stream);
+						let map = &mut *self_.map;
+						let r_ = r.as_mut().unwrap_or_else(|| map.get_mut(&k).unwrap());
+						if r_.as_mut().poll_forward(cx, stream).is_ready() {
+							let _ = v.take();
 						}
-					})
-					.fuse();
-					pin_mut!(stream);
-					let map = &mut *self_.map;
-					let r_ = r.as_mut().unwrap_or_else(|| map.get_mut(&k).unwrap());
-					if r_.as_mut().poll_pipe(cx, stream).is_ready() {
-						let _ = v.take();
+						if let Some(v) = v {
+							let _ = pending.insert(k, (v, r));
+							return Poll::Pending;
+						}
+						if let Some(r) = r {
+							let _ = self_.map.insert(k, r);
+						}
 					}
-					if let Some(v) = v {
-						let _ = pending.insert(k, (v, r));
+					*self_.pending = None;
+				}
+				Sum2::B(done) => {
+					let mut done_ = true;
+					self_
+						.map
+						.values_mut()
+						.zip(done.iter_mut())
+						.for_each(|(r, done)| {
+							if done.is_none() {
+								let stream = stream::empty();
+								pin_mut!(stream);
+								if let Poll::Ready(done_) = r.as_mut().poll_forward(cx, stream) {
+									*done = Some(done_);
+								} else {
+									done_ = false;
+								}
+							}
+						});
+					if !done_ {
 						return Poll::Pending;
 					}
-					if let Some(r) = r {
-						let _ = self_.map.insert(k, r);
-					}
+					let ret = self_
+						.map
+						.drain()
+						.zip(done.iter_mut())
+						.map(|((k, _), v)| (k, v.take().unwrap()))
+						.collect();
+					return Poll::Ready(ret);
 				}
-				*self_.pending = None;
-			} else {
-				for r in self_.map.values_mut() {
-					let stream = stream::empty();
-					pin_mut!(stream);
-					ready!(r.as_mut().poll_pipe(cx, stream));
-				}
-				return Poll::Ready(());
 			}
 		}
-	}
-}
-impl<R, T, U> ReducerAsync<HashMap<T, U>> for GroupByReducerBAsync<R, R::Async, T, U>
-where
-	R: Reducer<U> + Clone,
-	T: Eq + Hash,
-{
-	type Output = HashMap<T, R::Output>;
-
-	fn output<'a>(self: Pin<&'a mut Self>) -> Pin<Box<dyn Future<Output = Self::Output> + 'a>> {
-		Box::pin(async move {
-			let self_ = self.project();
-			join_all(
-				mem::take(self_.map)
-					.into_iter()
-					.map(|(k, mut v)| async move { (k, v.as_mut().output().await) }),
-			)
-			.await
-			.into_iter()
-			.collect()
-		})
 	}
 }
 

--- a/amadeus-core/src/par_sink/pipe.rs
+++ b/amadeus-core/src/par_sink/pipe.rs
@@ -1,36 +1,47 @@
 use derive_new::new;
 use pin_project::pin_project;
 use serde::{Deserialize, Serialize};
+use std::{
+	pin::Pin, task::{Context, Poll}
+};
 
 use super::{DistributedPipe, DistributedSink, ParallelPipe, ParallelSink, PipeTask};
 use crate::{
 	par_stream::{ParallelStream, StreamTask}, pipe::{Pipe as _, PipePipe, StreamExt, StreamPipe}
 };
 
+#[pin_project]
 #[derive(new)]
 #[must_use]
 pub struct Pipe<A, B> {
+	#[pin]
 	a: A,
 	b: B,
 }
 
 impl_par_dist! {
 	impl<A: ParallelStream, B: ParallelPipe<A::Item>> ParallelStream for Pipe<A, B> {
-		type Item = B::Item;
+		type Item = B::Output;
 		type Task = JoinTask<A::Task, B::Task>;
 
-		fn next_task(&mut self) -> Option<Self::Task> {
-			self.a.next_task().map(|a| {
-				let b = self.b.task();
-				JoinTask { a, b }
+		fn next_task(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Task>> {
+			let self_ = self.project();
+			let b = self_.b;
+			self_.a.next_task(cx).map(|task| {
+				task.map(|a| {
+					let b = b.task();
+					JoinTask { a, b }
+				})
 			})
 		}
 		fn size_hint(&self) -> (usize, Option<usize>) {
 			self.a.size_hint()
 		}
 	}
-	impl<A: ParallelPipe<Source>, B: ParallelPipe<A::Item>, Source> ParallelPipe<Source> for Pipe<A, B> {
-		type Item = B::Item;
+	impl<A: ParallelPipe<Input>, B: ParallelPipe<A::Output>, Input> ParallelPipe<Input>
+		for Pipe<A, B>
+	{
+		type Output = B::Output;
 		type Task = JoinTask<A::Task, B::Task>;
 
 		fn task(&self) -> Self::Task {
@@ -41,10 +52,8 @@ impl_par_dist! {
 	}
 }
 
-impl<A: ParallelPipe<Source>, B: ParallelSink<A::Item>, Source> ParallelSink<Source>
-	for Pipe<A, B>
-{
-	type Output = B::Output;
+impl<A: ParallelPipe<Input>, B: ParallelSink<A::Output>, Input> ParallelSink<Input> for Pipe<A, B> {
+	type Done = B::Done;
 	type Pipe = Pipe<A, B::Pipe>;
 	type ReduceA = B::ReduceA;
 	type ReduceC = B::ReduceC;
@@ -54,10 +63,10 @@ impl<A: ParallelPipe<Source>, B: ParallelSink<A::Item>, Source> ParallelSink<Sou
 		(Pipe::new(self.a, a), b, c)
 	}
 }
-impl<A: DistributedPipe<Source>, B: DistributedSink<A::Item>, Source> DistributedSink<Source>
+impl<A: DistributedPipe<Input>, B: DistributedSink<A::Output>, Input> DistributedSink<Input>
 	for Pipe<A, B>
 {
-	type Output = B::Output;
+	type Done = B::Done;
 	type Pipe = Pipe<A, B::Pipe>;
 	type ReduceA = B::ReduceA;
 	type ReduceB = B::ReduceB;
@@ -79,7 +88,7 @@ pub struct JoinTask<A, B> {
 }
 
 impl<A: StreamTask, B: PipeTask<A::Item>> StreamTask for JoinTask<A, B> {
-	type Item = B::Item;
+	type Item = B::Output;
 	type Async = StreamPipe<A::Async, B::Async>;
 
 	fn into_async(self) -> Self::Async {
@@ -87,8 +96,8 @@ impl<A: StreamTask, B: PipeTask<A::Item>> StreamTask for JoinTask<A, B> {
 	}
 }
 
-impl<A: PipeTask<Source>, B: PipeTask<A::Item>, Source> PipeTask<Source> for JoinTask<A, B> {
-	type Item = B::Item;
+impl<A: PipeTask<Input>, B: PipeTask<A::Output>, Input> PipeTask<Input> for JoinTask<A, B> {
+	type Output = B::Output;
 	type Async = PipePipe<A::Async, B::Async>;
 
 	fn into_async(self) -> Self::Async {

--- a/amadeus-core/src/par_sink/sample.rs
+++ b/amadeus-core/src/par_sink/sample.rs
@@ -12,18 +12,23 @@ use super::{
 
 #[derive(new)]
 #[must_use]
-pub struct SampleUnstable<I> {
-	i: I,
+pub struct SampleUnstable<P> {
+	pipe: P,
 	samples: usize,
 }
 
 impl_par_dist! {
-	impl<I: ParallelPipe<Source>, Source> ParallelSink<Source>
-		for SampleUnstable<I>
+	impl<P: ParallelPipe<Input>, Input> ParallelSink<Input> for SampleUnstable<P>
 	where
-		I::Item: Send + 'static,
+		P::Output: Send + 'static,
 	{
-		folder_par_sink!(SampleUnstableFolder, SumFolder<SASampleUnstable<I::Item>>, self, SampleUnstableFolder::new(self.samples), SumFolder::new());
+		folder_par_sink!(
+			SampleUnstableFolder,
+			SumFolder<SASampleUnstable<P::Output>>,
+			self,
+			SampleUnstableFolder::new(self.samples),
+			SumFolder::new()
+		);
 	}
 }
 
@@ -32,33 +37,38 @@ pub struct SampleUnstableFolder {
 	samples: usize,
 }
 
-impl<A> FolderSync<A> for SampleUnstableFolder {
-	type Output = SASampleUnstable<A>;
+impl<Item> FolderSync<Item> for SampleUnstableFolder {
+	type Done = SASampleUnstable<Item>;
 
-	fn zero(&mut self) -> Self::Output {
+	fn zero(&mut self) -> Self::Done {
 		SASampleUnstable::new(self.samples)
 	}
-	fn push(&mut self, state: &mut Self::Output, item: A) {
+	fn push(&mut self, state: &mut Self::Done, item: Item) {
 		state.push(item, &mut thread_rng())
 	}
 }
 
 #[derive(new)]
 #[must_use]
-pub struct MostFrequent<I> {
-	i: I,
+pub struct MostFrequent<P> {
+	pipe: P,
 	n: usize,
 	probability: f64,
 	tolerance: f64,
 }
 
 impl_par_dist! {
-	impl<I: ParallelPipe<Source>, Source> ParallelSink<Source>
-		for MostFrequent<I>
+	impl<P: ParallelPipe<Input>, Input> ParallelSink<Input> for MostFrequent<P>
 	where
-		I::Item: Clone + Hash + Eq + Send + 'static,
+		P::Output: Clone + Hash + Eq + Send + 'static,
 	{
-		folder_par_sink!(MostFrequentFolder, SumZeroFolder<Top<I::Item, usize>>, self, MostFrequentFolder::new(self.n, self.probability, self.tolerance), SumZeroFolder::new(Top::new(self.n, self.probability, self.tolerance, ())));
+		folder_par_sink!(
+			MostFrequentFolder,
+			SumZeroFolder<Top<P::Output, usize>>,
+			self,
+			MostFrequentFolder::new(self.n, self.probability, self.tolerance),
+			SumZeroFolder::new(Top::new(self.n, self.probability, self.tolerance, ()))
+		);
 	}
 }
 
@@ -69,24 +79,24 @@ pub struct MostFrequentFolder {
 	tolerance: f64,
 }
 
-impl<A> FolderSync<A> for MostFrequentFolder
+impl<Item> FolderSync<Item> for MostFrequentFolder
 where
-	A: Clone + Hash + Eq + Send + 'static,
+	Item: Clone + Hash + Eq + Send + 'static,
 {
-	type Output = Top<A, usize>;
+	type Done = Top<Item, usize>;
 
-	fn zero(&mut self) -> Self::Output {
+	fn zero(&mut self) -> Self::Done {
 		Top::new(self.n, self.probability, self.tolerance, ())
 	}
-	fn push(&mut self, state: &mut Self::Output, item: A) {
+	fn push(&mut self, state: &mut Self::Done, item: Item) {
 		state.push(item, &1)
 	}
 }
 
 #[derive(new)]
 #[must_use]
-pub struct MostDistinct<I> {
-	i: I,
+pub struct MostDistinct<P> {
+	pipe: P,
 	n: usize,
 	probability: f64,
 	tolerance: f64,
@@ -94,12 +104,23 @@ pub struct MostDistinct<I> {
 }
 
 impl_par_dist! {
-	impl<I: ParallelPipe<Source, Item = (A, B)>, Source, A, B> ParallelSink<Source> for MostDistinct<I>
+	impl<P: ParallelPipe<Input, Output = (A, B)>, Input, A, B> ParallelSink<Input> for MostDistinct<P>
 	where
 		A: Clone + Hash + Eq + Send + 'static,
 		B: Hash + 'static,
 	{
-		folder_par_sink!(MostDistinctFolder, SumZeroFolder<Top<A, HyperLogLogMagnitude<B>>>, self, MostDistinctFolder::new(self.n, self.probability, self.tolerance, self.error_rate), SumZeroFolder::new(Top::new(self.n, self.probability, self.tolerance, self.error_rate)));
+		folder_par_sink!(
+			MostDistinctFolder,
+			SumZeroFolder<Top<A, HyperLogLogMagnitude<B>>>,
+			self,
+			MostDistinctFolder::new(self.n, self.probability, self.tolerance, self.error_rate),
+			SumZeroFolder::new(Top::new(
+				self.n,
+				self.probability,
+				self.tolerance,
+				self.error_rate
+			))
+		);
 	}
 }
 
@@ -116,12 +137,12 @@ where
 	A: Clone + Hash + Eq + Send + 'static,
 	B: Hash + 'static,
 {
-	type Output = Top<A, HyperLogLogMagnitude<B>>;
+	type Done = Top<A, HyperLogLogMagnitude<B>>;
 
-	fn zero(&mut self) -> Self::Output {
+	fn zero(&mut self) -> Self::Done {
 		Top::new(self.n, self.probability, self.tolerance, self.error_rate)
 	}
-	fn push(&mut self, state: &mut Self::Output, item: (A, B)) {
+	fn push(&mut self, state: &mut Self::Done, item: (A, B)) {
 		state.push(item.0, &item.1)
 	}
 }

--- a/amadeus-core/src/par_stream/identity.rs
+++ b/amadeus-core/src/par_stream/identity.rs
@@ -16,7 +16,7 @@ pub struct Identity;
 
 impl_par_dist! {
 	impl<Item> ParallelPipe<Item> for Identity {
-		type Item = Item;
+		type Output = Item;
 		type Task = IdentityTask;
 
 		fn task(&self) -> Self::Task {
@@ -200,7 +200,7 @@ mod workaround {
 #[derive(Clone, Serialize, Deserialize)]
 pub struct IdentityTask;
 impl<Item> PipeTask<Item> for IdentityTask {
-	type Item = Item;
+	type Output = Item;
 	type Async = IdentityTask;
 
 	fn into_async(self) -> Self::Async {
@@ -208,11 +208,11 @@ impl<Item> PipeTask<Item> for IdentityTask {
 	}
 }
 impl<Item> crate::pipe::Pipe<Item> for IdentityTask {
-	type Item = Item;
+	type Output = Item;
 
 	fn poll_next(
 		self: Pin<&mut Self>, cx: &mut Context, stream: Pin<&mut impl Stream<Item = Item>>,
-	) -> Poll<Option<Item>> {
+	) -> Poll<Option<Self::Output>> {
 		stream.poll_next(cx)
 	}
 }

--- a/amadeus-core/src/par_stream/map.rs
+++ b/amadeus-core/src/par_stream/map.rs
@@ -2,44 +2,53 @@ use derive_new::new;
 use pin_project::pin_project;
 use serde::{Deserialize, Serialize};
 use serde_closure::traits::FnMut;
+use std::{
+	pin::Pin, task::{Context, Poll}
+};
 
 use super::{ParallelPipe, ParallelStream, PipeTask, StreamTask};
 
+#[pin_project]
 #[derive(new)]
 #[must_use]
-pub struct Map<I, F> {
-	i: I,
+pub struct Map<P, F> {
+	#[pin]
+	pipe: P,
 	f: F,
 }
 
 impl_par_dist! {
-	impl<I: ParallelStream, F, R> ParallelStream for Map<I, F>
+	impl<P: ParallelStream, F, R> ParallelStream for Map<P, F>
 	where
-		F: FnMut<(I::Item,), Output = R> + Clone + Send + 'static,
+		F: FnMut<(P::Item,), Output = R> + Clone + Send + 'static,
 	{
 		type Item = R;
-		type Task = MapTask<I::Task, F>;
+		type Task = MapTask<P::Task, F>;
 
 		fn size_hint(&self) -> (usize, Option<usize>) {
-			self.i.size_hint()
+			self.pipe.size_hint()
 		}
-		fn next_task(&mut self) -> Option<Self::Task> {
-			self.i.next_task().map(|task| {
-				let f = self.f.clone();
-				MapTask { task, f }
+		fn next_task(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Task>> {
+			let self_ = self.project();
+			let f = self_.f;
+			self_.pipe.next_task(cx).map(|task| {
+				task.map(|task| {
+					let f = f.clone();
+					MapTask { task, f }
+				})
 			})
 		}
 	}
 
-	impl<I: ParallelPipe<Source>, F, R, Source> ParallelPipe<Source> for Map<I, F>
+	impl<P: ParallelPipe<Input>, F, R, Input> ParallelPipe<Input> for Map<P, F>
 	where
-		F: FnMut<(I::Item,), Output = R> + Clone + Send + 'static,
+		F: FnMut<(P::Output,), Output = R> + Clone + Send + 'static,
 	{
-		type Item = R;
-		type Task = MapTask<I::Task, F>;
+		type Output = R;
+		type Task = MapTask<P::Task, F>;
 
 		fn task(&self) -> Self::Task {
-			let task = self.i.task();
+			let task = self.pipe.task();
 			let f = self.f.clone();
 			MapTask { task, f }
 		}
@@ -59,18 +68,18 @@ where
 	F: FnMut<(C::Item,), Output = R> + Clone,
 {
 	type Item = R;
-	type Async = crate::pipe::Map<C::Async, F, R>;
+	type Async = crate::pipe::Map<C::Async, F>;
 
 	fn into_async(self) -> Self::Async {
 		crate::pipe::Map::new(self.task.into_async(), self.f)
 	}
 }
-impl<C: PipeTask<Source>, F, R, Source> PipeTask<Source> for MapTask<C, F>
+impl<C: PipeTask<Input>, F, R, Input> PipeTask<Input> for MapTask<C, F>
 where
-	F: FnMut<(C::Item,), Output = R> + Clone,
+	F: FnMut<(C::Output,), Output = R> + Clone,
 {
-	type Item = R;
-	type Async = crate::pipe::Map<C::Async, F, R>;
+	type Output = R;
+	type Async = crate::pipe::Map<C::Async, F>;
 
 	fn into_async(self) -> Self::Async {
 		crate::pipe::Map::new(self.task.into_async(), self.f)

--- a/amadeus-core/src/par_stream/sum_type.rs
+++ b/amadeus-core/src/par_stream/sum_type.rs
@@ -18,18 +18,18 @@ impl_par_dist! {
 				Self::B(i) => i.size_hint(),
 			}
 		}
-		fn next_task(&mut self) -> Option<Self::Task> {
-			match self {
-				Self::A(i) => i.next_task().map(Sum2::A),
-				Self::B(i) => i.next_task().map(Sum2::B),
+		fn next_task(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Task>> {
+			match self.as_pin_mut() {
+				Sum2::A(i) => i.next_task(cx).map(|task| task.map(Sum2::A)),
+				Sum2::B(i) => i.next_task(cx).map(|task| task.map(Sum2::B)),
 			}
 		}
 	}
 
-	impl<A: ParallelPipe<Source>, B: ParallelPipe<Source, Item = A::Item>, Source>
-		ParallelPipe<Source> for Sum2<A, B>
+	impl<A: ParallelPipe<Input>, B: ParallelPipe<Input, Output = A::Output>, Input>
+		ParallelPipe<Input> for Sum2<A, B>
 	{
-		type Item = A::Item;
+		type Output = A::Output;
 		type Task = Sum2<A::Task, B::Task>;
 
 		fn task(&self) -> Self::Task {
@@ -44,6 +44,7 @@ impl_par_dist! {
 impl<A: StreamTask, B: StreamTask<Item = A::Item>> StreamTask for Sum2<A, B> {
 	type Item = A::Item;
 	type Async = Sum2<A::Async, B::Async>;
+
 	fn into_async(self) -> Self::Async {
 		match self {
 			Sum2::A(a) => Sum2::A(a.into_async()),
@@ -51,11 +52,12 @@ impl<A: StreamTask, B: StreamTask<Item = A::Item>> StreamTask for Sum2<A, B> {
 		}
 	}
 }
-impl<A: PipeTask<Source>, B: PipeTask<Source, Item = A::Item>, Source> PipeTask<Source>
+impl<A: PipeTask<Input>, B: PipeTask<Input, Output = A::Output>, Input> PipeTask<Input>
 	for Sum2<A, B>
 {
-	type Item = A::Item;
+	type Output = A::Output;
 	type Async = Sum2<A::Async, B::Async>;
+
 	fn into_async(self) -> Self::Async {
 		match self {
 			Sum2::A(a) => Sum2::A(a.into_async()),
@@ -64,12 +66,12 @@ impl<A: PipeTask<Source>, B: PipeTask<Source, Item = A::Item>, Source> PipeTask<
 	}
 }
 
-impl<A: Pipe<Source>, B: Pipe<Source, Item = A::Item>, Source> Pipe<Source> for Sum2<A, B> {
-	type Item = A::Item;
+impl<A: Pipe<Input>, B: Pipe<Input, Output = A::Output>, Input> Pipe<Input> for Sum2<A, B> {
+	type Output = A::Output;
 
 	fn poll_next(
-		self: Pin<&mut Self>, cx: &mut Context, stream: Pin<&mut impl Stream<Item = Source>>,
-	) -> Poll<Option<Self::Item>> {
+		self: Pin<&mut Self>, cx: &mut Context, stream: Pin<&mut impl Stream<Item = Input>>,
+	) -> Poll<Option<Self::Output>> {
 		match self.as_pin_mut() {
 			Sum2::A(task) => task.poll_next(cx, stream),
 			Sum2::B(task) => task.poll_next(cx, stream),

--- a/amadeus-core/src/par_stream/update.rs
+++ b/amadeus-core/src/par_stream/update.rs
@@ -10,41 +10,47 @@ use std::{
 use super::{ParallelPipe, ParallelStream, PipeTask, StreamTask};
 use crate::pipe::Pipe;
 
+#[pin_project]
 #[derive(new)]
 #[must_use]
-pub struct Update<I, F> {
-	i: I,
+pub struct Update<P, F> {
+	#[pin]
+	pipe: P,
 	f: F,
 }
 
 impl_par_dist! {
-	impl<I: ParallelStream, F> ParallelStream for Update<I, F>
+	impl<P: ParallelStream, F> ParallelStream for Update<P, F>
 	where
-		F: for<'a>FnMut<(&'a mut I::Item,), Output = ()> + Clone + Send + 'static,
+		F: for<'a> FnMut<(&'a mut P::Item,), Output = ()> + Clone + Send + 'static,
 	{
-		type Item = I::Item;
-		type Task = UpdateTask<I::Task, F>;
+		type Item = P::Item;
+		type Task = UpdateTask<P::Task, F>;
 
 		fn size_hint(&self) -> (usize, Option<usize>) {
-			self.i.size_hint()
+			self.pipe.size_hint()
 		}
-		fn next_task(&mut self) -> Option<Self::Task> {
-			self.i.next_task().map(|task| {
-				let f = self.f.clone();
-				UpdateTask { task, f }
+		fn next_task(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Task>> {
+			let self_ = self.project();
+			let f = self_.f;
+			self_.pipe.next_task(cx).map(|task| {
+				task.map(|task| {
+					let f = f.clone();
+					UpdateTask { task, f }
+				})
 			})
 		}
 	}
 
-	impl<I: ParallelPipe<Source>, F, Source> ParallelPipe<Source> for Update<I, F>
+	impl<P: ParallelPipe<Input>, F, Input> ParallelPipe<Input> for Update<P, F>
 	where
-		F: for<'a>FnMut<(&'a mut I::Item,), Output = ()> + Clone + Send + 'static,
+		F: for<'a> FnMut<(&'a mut P::Output,), Output = ()> + Clone + Send + 'static,
 	{
-		type Item = I::Item;
-		type Task = UpdateTask<I::Task, F>;
+		type Output = P::Output;
+		type Task = UpdateTask<P::Task, F>;
 
 		fn task(&self) -> Self::Task {
-			let task = self.i.task();
+			let task = self.pipe.task();
 			let f = self.f.clone();
 			UpdateTask { task, f }
 		}
@@ -65,6 +71,7 @@ where
 {
 	type Item = C::Item;
 	type Async = UpdateTask<C::Async, F>;
+
 	fn into_async(self) -> Self::Async {
 		UpdateTask {
 			task: self.task.into_async(),
@@ -72,12 +79,13 @@ where
 		}
 	}
 }
-impl<C: PipeTask<Source>, F, Source> PipeTask<Source> for UpdateTask<C, F>
+impl<C: PipeTask<Input>, F, Input> PipeTask<Input> for UpdateTask<C, F>
 where
-	F: for<'a> FnMut<(&'a mut <C as PipeTask<Source>>::Item,), Output = ()> + Clone,
+	F: for<'a> FnMut<(&'a mut <C as PipeTask<Input>>::Output,), Output = ()> + Clone,
 {
-	type Item = C::Item;
+	type Output = C::Output;
 	type Async = UpdateTask<C::Async, F>;
+
 	fn into_async(self) -> Self::Async {
 		UpdateTask {
 			task: self.task.into_async(),
@@ -104,15 +112,15 @@ where
 	}
 }
 
-impl<C: Pipe<Source>, F, Source> Pipe<Source> for UpdateTask<C, F>
+impl<C: Pipe<Input>, F, Input> Pipe<Input> for UpdateTask<C, F>
 where
-	F: for<'a> FnMut<(&'a mut C::Item,), Output = ()> + Clone,
+	F: for<'a> FnMut<(&'a mut C::Output,), Output = ()> + Clone,
 {
-	type Item = C::Item;
+	type Output = C::Output;
 
 	fn poll_next(
-		self: Pin<&mut Self>, cx: &mut Context, stream: Pin<&mut impl Stream<Item = Source>>,
-	) -> Poll<Option<Self::Item>> {
+		self: Pin<&mut Self>, cx: &mut Context, stream: Pin<&mut impl Stream<Item = Input>>,
+	) -> Poll<Option<Self::Output>> {
 		let mut self_ = self.project();
 		let (task, f) = (self_.task, &mut self_.f);
 		task.poll_next(cx, stream).map(|item| {


### PR DESCRIPTION
*  [x] Combine Sink::{poll, output} to avoid unnecessary Boxing
*  [x] Make various naming consistent

