### PR TITLE
WIP: Remove the 'static bound from everywhere

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,13 @@ wasm-bindgen-test = "0.3"
 [build-dependencies]
 rustversion = "1.0"
 
+[profile.bench]
+codegen-units = 1
+debug = 2
+incremental = false
+lto = true
+# panic = "abort" # this is disallowed by cargo currently
+
 [[example]]
 name = "cloudfront_logs"
 required-features = ["aws"]

--- a/amadeus-core/src/file.rs
+++ b/amadeus-core/src/file.rs
@@ -201,15 +201,15 @@ pub trait File {
 	async fn partitions(self) -> Result<Vec<Self::Partition>, Self::Error>;
 }
 #[async_trait(?Send)]
-pub trait Partition: Clone + fmt::Debug + ProcessSend + 'static {
+pub trait Partition: Clone + fmt::Debug + ProcessSend {
 	type Page: Page;
-	type Error: Error + Clone + PartialEq + ProcessSend + 'static;
+	type Error: Error + Clone + PartialEq + ProcessSend;
 
 	async fn pages(self) -> Result<Vec<Self::Page>, Self::Error>;
 }
 #[allow(clippy::len_without_is_empty)]
 pub trait Page {
-	type Error: Error + Clone + PartialEq + Into<io::Error> + ProcessSend + 'static;
+	type Error: Error + Clone + PartialEq + Into<io::Error> + ProcessSend;
 
 	fn len(&self) -> LocalBoxFuture<'static, Result<u64, Self::Error>>;
 	fn read(

--- a/amadeus-core/src/into_par_stream/iterator.rs
+++ b/amadeus-core/src/into_par_stream/iterator.rs
@@ -28,7 +28,7 @@ impl_par_dist_rename! {
 
 	impl<I: Iterator> ParallelStream for IterParStream<I>
 	where
-		I::Item: Send + 'static,
+		I::Item: Send,
 	{
 		type Item = I::Item;
 		type Task = IterStreamTask<I::Item>;
@@ -76,7 +76,7 @@ impl_par_dist_rename! {
 	impl<Idx> IntoParallelStream for Range<Idx>
 	where
 		Self: Iterator,
-		<Self as Iterator>::Item: Send + 'static,
+		<Self as Iterator>::Item: Send,
 	{
 		type ParStream = IterParStream<Self>;
 		type Item = <Self as Iterator>::Item;
@@ -93,7 +93,7 @@ impl_par_dist_rename! {
 	impl<Idx> IntoParallelStream for RangeFrom<Idx>
 	where
 		Self: Iterator,
-		<Self as Iterator>::Item: Send + 'static,
+		<Self as Iterator>::Item: Send,
 	{
 		type ParStream = IterParStream<Self>;
 		type Item = <Self as Iterator>::Item;
@@ -110,7 +110,7 @@ impl_par_dist_rename! {
 	impl<Idx> IntoParallelStream for RangeInclusive<Idx>
 	where
 		Self: Iterator,
-		<Self as Iterator>::Item: Send + 'static,
+		<Self as Iterator>::Item: Send,
 	{
 		type ParStream = IterParStream<Self>;
 		type Item = <Self as Iterator>::Item;

--- a/amadeus-core/src/into_par_stream/slice.rs
+++ b/amadeus-core/src/into_par_stream/slice.rs
@@ -12,7 +12,7 @@ use crate::pool::ProcessSend;
 impl_par_dist_rename! {
 	impl<T> IntoParallelStream for [T]
 	where
-		T: Send + 'static,
+		T: Send,
 	{
 		type ParStream = Never;
 		type Item = Never;
@@ -27,7 +27,7 @@ impl_par_dist_rename! {
 
 	impl<'a, T: Clone> IntoParallelStream for &'a [T]
 	where
-		T: Send + 'static,
+		T: Send,
 	{
 		type ParStream = IterParStream<iter::Cloned<slice::Iter<'a, T>>>;
 		type Item = T;

--- a/amadeus-core/src/par_pipe.rs
+++ b/amadeus-core/src/par_pipe.rs
@@ -29,7 +29,7 @@ macro_rules! pipe {
 			#[inline]
 			fn inspect<F>(self, f: F) -> Inspect<Self, F>
 			where
-				F: $fns::FnMut(&Self::Output) + Clone + $send + 'static,
+				F: $fns::FnMut(&Self::Output) + Clone + $send,
 				Self: Sized,
 			{
 				$assert_pipe(Inspect::new(self, f))
@@ -38,7 +38,7 @@ macro_rules! pipe {
 			#[inline]
 			fn update<F>(self, f: F) -> Update<Self, F>
 			where
-				F: $fns::FnMut(&mut Self::Output) + Clone + $send + 'static,
+				F: $fns::FnMut(&mut Self::Output) + Clone + $send,
 				Self: Sized,
 			{
 				$assert_pipe(Update::new(self, f))
@@ -47,7 +47,7 @@ macro_rules! pipe {
 			#[inline]
 			fn map<B, F>(self, f: F) -> Map<Self, F>
 			where
-				F: $fns::FnMut(Self::Output) -> B + Clone + $send + 'static,
+				F: $fns::FnMut(Self::Output) -> B + Clone + $send,
 				Self: Sized,
 			{
 				$assert_pipe(Map::new(self, f))
@@ -56,7 +56,7 @@ macro_rules! pipe {
 			#[inline]
 			fn flat_map<B, F>(self, f: F) -> FlatMap<Self, F>
 			where
-				F: $fns::FnMut(Self::Output) -> B + Clone + $send + 'static,
+				F: $fns::FnMut(Self::Output) -> B + Clone + $send,
 				B: Stream,
 				Self: Sized,
 			{
@@ -66,7 +66,7 @@ macro_rules! pipe {
 			#[inline]
 			fn filter<F>(self, f: F) -> Filter<Self, F>
 			where
-				F: $fns::FnMut(&Self::Output) -> bool + Clone + $send + 'static,
+				F: $fns::FnMut(&Self::Output) -> bool + Clone + $send,
 				Self: Sized,
 			{
 				$assert_pipe(Filter::new(self, f))
@@ -115,7 +115,7 @@ macro_rules! pipe {
 			#[inline]
 			fn for_each<F>(self, f: F) -> ForEach<Self, F>
 			where
-				F: $fns::FnMut(Self::Output) + Clone + $send + 'static,
+				F: $fns::FnMut(Self::Output) + Clone + $send,
 				Self: Sized,
 			{
 				$assert_sink(ForEach::new(self, f))
@@ -124,9 +124,9 @@ macro_rules! pipe {
 			#[inline]
 			fn fold<ID, F, B>(self, identity: ID, op: F) -> Fold<Self, ID, F, B>
 			where
-				ID: $fns::FnMut() -> B + Clone + $send + 'static,
-				F: $fns::FnMut(B, Either<Self::Output, B>) -> B + Clone + $send + 'static,
-				B: $send + 'static,
+				ID: $fns::FnMut() -> B + Clone + $send,
+				F: $fns::FnMut(B, Either<Self::Output, B>) -> B + Clone + $send,
+				B: $send,
 				Self: Sized,
 			{
 				$assert_sink(Fold::new(self, identity, op))
@@ -135,12 +135,11 @@ macro_rules! pipe {
 			#[inline]
 			fn group_by<S, A, B>(self, sink: S) -> GroupBy<Self, S>
 			where
-				A: Eq + Hash + $send + 'static,
+				A: Eq + Hash + $send,
 				S: $sink<B>,
-				<S::Pipe as $pipe<B>>::Task: Clone + $send + 'static,
-				S::ReduceA: 'static,
+				<S::Pipe as $pipe<B>>::Task: Clone + $send,
 				S::ReduceC: Clone,
-				S::Done: $send + 'static,
+				S::Done: $send,
 				Self: $pipe<Input, Output = (A, B)> + Sized,
 			{
 				$assert_sink(GroupBy::new(self, sink))
@@ -149,7 +148,7 @@ macro_rules! pipe {
 			#[inline]
 			fn histogram(self) -> Histogram<Self>
 			where
-				Self::Output: Hash + Ord + $send + 'static,
+				Self::Output: Hash + Ord + $send,
 				Self: Sized,
 			{
 				$assert_sink(Histogram::new(self))
@@ -166,7 +165,7 @@ macro_rules! pipe {
 			#[inline]
 			fn sum<B>(self) -> Sum<Self, B>
 			where
-				B: iter::Sum<Self::Output> + iter::Sum<B> + $send + 'static,
+				B: iter::Sum<Self::Output> + iter::Sum<B> + $send,
 				Self: Sized,
 			{
 				$assert_sink(Sum::new(self))
@@ -175,8 +174,8 @@ macro_rules! pipe {
 			#[inline]
 			fn combine<F>(self, f: F) -> Combine<Self, F>
 			where
-				F: $fns::FnMut(Self::Output, Self::Output) -> Self::Output + Clone + $send + 'static,
-				Self::Output: $send + 'static,
+				F: $fns::FnMut(Self::Output, Self::Output) -> Self::Output + Clone + $send,
+				Self::Output: $send,
 				Self: Sized,
 			{
 				$assert_sink(Combine::new(self, f))
@@ -185,7 +184,7 @@ macro_rules! pipe {
 			#[inline]
 			fn max(self) -> Max<Self>
 			where
-				Self::Output: Ord + $send + 'static,
+				Self::Output: Ord + $send,
 				Self: Sized,
 			{
 				$assert_sink(Max::new(self))
@@ -194,8 +193,8 @@ macro_rules! pipe {
 			#[inline]
 			fn max_by<F>(self, f: F) -> MaxBy<Self, F>
 			where
-				F: $fns::FnMut(&Self::Output, &Self::Output) -> Ordering + Clone + $send + 'static,
-				Self::Output: $send + 'static,
+				F: $fns::FnMut(&Self::Output, &Self::Output) -> Ordering + Clone + $send,
+				Self::Output: $send,
 				Self: Sized,
 			{
 				$assert_sink(MaxBy::new(self, f))
@@ -204,9 +203,9 @@ macro_rules! pipe {
 			#[inline]
 			fn max_by_key<F, B>(self, f: F) -> MaxByKey<Self, F>
 			where
-				F: $fns::FnMut(&Self::Output) -> B + Clone + $send + 'static,
-				B: Ord + 'static,
-				Self::Output: $send + 'static,
+				F: $fns::FnMut(&Self::Output) -> B + Clone + $send,
+				B: Ord,
+				Self::Output: $send,
 				Self: Sized,
 			{
 				$assert_sink(MaxByKey::new(self, f))
@@ -215,7 +214,7 @@ macro_rules! pipe {
 			#[inline]
 			fn min(self) -> Min<Self>
 			where
-				Self::Output: Ord + $send + 'static,
+				Self::Output: Ord + $send,
 				Self: Sized,
 			{
 				$assert_sink(Min::new(self))
@@ -224,8 +223,8 @@ macro_rules! pipe {
 			#[inline]
 			fn min_by<F>(self, f: F) -> MinBy<Self, F>
 			where
-				F: $fns::FnMut(&Self::Output, &Self::Output) -> Ordering + Clone + $send + 'static,
-				Self::Output: $send + 'static,
+				F: $fns::FnMut(&Self::Output, &Self::Output) -> Ordering + Clone + $send,
+				Self::Output: $send,
 				Self: Sized,
 			{
 				$assert_sink(MinBy::new(self, f))
@@ -234,9 +233,9 @@ macro_rules! pipe {
 			#[inline]
 			fn min_by_key<F, B>(self, f: F) -> MinByKey<Self, F>
 			where
-				F: $fns::FnMut(&Self::Output) -> B + Clone + $send + 'static,
-				B: Ord + 'static,
-				Self::Output: $send + 'static,
+				F: $fns::FnMut(&Self::Output) -> B + Clone + $send,
+				B: Ord,
+				Self::Output: $send,
 				Self: Sized,
 			{
 				$assert_sink(MinByKey::new(self, f))
@@ -245,7 +244,7 @@ macro_rules! pipe {
 			#[inline]
 			fn most_frequent(self, n: usize, probability: f64, tolerance: f64) -> MostFrequent<Self>
 			where
-				Self::Output: Hash + Eq + Clone + $send + 'static,
+				Self::Output: Hash + Eq + Clone + $send,
 				Self: Sized,
 			{
 				$assert_sink(MostFrequent::new(self, n, probability, tolerance))
@@ -257,8 +256,8 @@ macro_rules! pipe {
 			) -> MostDistinct<Self>
 			where
 				Self: $pipe<Input, Output = (A, B)> + Sized,
-				A: Hash + Eq + Clone + $send + 'static,
-				B: Hash + 'static,
+				A: Hash + Eq + Clone + $send,
+				B: Hash,
 			{
 				$assert_sink(MostDistinct::new(
 					self,
@@ -272,7 +271,7 @@ macro_rules! pipe {
 			#[inline]
 			fn sample_unstable(self, samples: usize) -> SampleUnstable<Self>
 			where
-				Self::Output: $send + 'static,
+				Self::Output: $send,
 				Self: Sized,
 			{
 				$assert_sink(SampleUnstable::new(self, samples))
@@ -281,7 +280,7 @@ macro_rules! pipe {
 			#[inline]
 			fn all<F>(self, f: F) -> All<Self, F>
 			where
-				F: $fns::FnMut(Self::Output) -> bool + Clone + $send + 'static,
+				F: $fns::FnMut(Self::Output) -> bool + Clone + $send,
 				Self: Sized,
 			{
 				$assert_sink(All::new(self, f))
@@ -290,7 +289,7 @@ macro_rules! pipe {
 			#[inline]
 			fn any<F>(self, f: F) -> Any<Self, F>
 			where
-				F: $fns::FnMut(Self::Output) -> bool + Clone + $send + 'static,
+				F: $fns::FnMut(Self::Output) -> bool + Clone + $send,
 				Self: Sized,
 			{
 				$assert_sink(Any::new(self, f))

--- a/amadeus-core/src/par_sink.rs
+++ b/amadeus-core/src/par_sink.rs
@@ -31,12 +31,12 @@ pub trait Reducer<Item> {
 	fn into_async(self) -> Self::Async;
 }
 pub trait ReducerSend<Item>: Reducer<Item, Done = <Self as ReducerSend<Item>>::Done> {
-	type Done: Send + 'static;
+	type Done: Send;
 }
 pub trait ReducerProcessSend<Item>:
 	ReducerSend<Item, Done = <Self as ReducerProcessSend<Item>>::Done>
 {
-	type Done: ProcessSend + 'static;
+	type Done: ProcessSend;
 }
 
 #[must_use]

--- a/amadeus-core/src/par_sink/all.rs
+++ b/amadeus-core/src/par_sink/all.rs
@@ -22,7 +22,7 @@ pub struct All<P, F> {
 
 impl<P: ParallelPipe<Item>, Item, F> ParallelSink<Item> for All<P, F>
 where
-	F: FnMut<(P::Output,), Output = bool> + Clone + Send + 'static,
+	F: FnMut<(P::Output,), Output = bool> + Clone + Send,
 {
 	type Done = bool;
 	type Pipe = P;
@@ -35,7 +35,7 @@ where
 }
 impl<P: DistributedPipe<Item>, Item, F> DistributedSink<Item> for All<P, F>
 where
-	F: FnMut<(P::Output,), Output = bool> + Clone + ProcessSend + 'static,
+	F: FnMut<(P::Output,), Output = bool> + Clone + ProcessSend,
 {
 	type Done = bool;
 	type Pipe = P;

--- a/amadeus-core/src/par_sink/any.rs
+++ b/amadeus-core/src/par_sink/any.rs
@@ -22,7 +22,7 @@ pub struct Any<P, F> {
 
 impl<P: ParallelPipe<Item>, Item, F> ParallelSink<Item> for Any<P, F>
 where
-	F: FnMut<(P::Output,), Output = bool> + Clone + Send + 'static,
+	F: FnMut<(P::Output,), Output = bool> + Clone + Send,
 {
 	type Done = bool;
 	type Pipe = P;
@@ -35,7 +35,7 @@ where
 }
 impl<P: DistributedPipe<Item>, Item, F> DistributedSink<Item> for Any<P, F>
 where
-	F: FnMut<(P::Output,), Output = bool> + Clone + ProcessSend + 'static,
+	F: FnMut<(P::Output,), Output = bool> + Clone + ProcessSend,
 {
 	type Done = bool;
 	type Pipe = P;

--- a/amadeus-core/src/par_sink/collect.rs
+++ b/amadeus-core/src/par_sink/collect.rs
@@ -63,7 +63,7 @@ pub trait FromDistributedStream<T>: Sized {
 	>;
 
 	fn reducers() -> (Self::ReduceA, Self::ReduceB, Self::ReduceC);
-	// 	fn from_dist_stream<P>(dist_stream: P, pool: &Pool) -> Self where T: Serialize + DeserializeOwned + Send + 'static, P: IntoDistributedStream<Item = T>, <<P as IntoDistributedStream>::Iter as DistributedStream>::Task: Serialize + DeserializeOwned + Send + 'static;
+	// 	fn from_dist_stream<P>(dist_stream: P, pool: &Pool) -> Self where T: Serialize + DeserializeOwned + Send, P: IntoDistributedStream<Item = T>, <<P as IntoDistributedStream>::Iter as DistributedStream>::Task: Serialize + DeserializeOwned + Send;
 }
 
 #[derive(Educe, Serialize, Deserialize, new)]
@@ -81,13 +81,13 @@ impl<Item, T: Default + Extend<Item>> Reducer<Item> for PushReducer<Item, T> {
 }
 impl<Item, T: Default + Extend<Item>> ReducerProcessSend<Item> for PushReducer<Item, T>
 where
-	T: ProcessSend + 'static,
+	T: ProcessSend,
 {
 	type Done = T;
 }
 impl<Item, T: Default + Extend<Item>> ReducerSend<Item> for PushReducer<Item, T>
 where
-	T: Send + 'static,
+	T: Send,
 {
 	type Done = T;
 }
@@ -126,14 +126,14 @@ impl<Item: IntoIterator<Item = B>, T: Default + Extend<B>, B> Reducer<Item>
 impl<Item: IntoIterator<Item = B>, T: Default + Extend<B>, B> ReducerProcessSend<Item>
 	for ExtendReducer<Item, T>
 where
-	T: ProcessSend + 'static,
+	T: ProcessSend,
 {
 	type Done = T;
 }
 impl<Item: IntoIterator<Item = B>, T: Default + Extend<B>, B> ReducerSend<Item>
 	for ExtendReducer<Item, T>
 where
-	T: Send + 'static,
+	T: Send,
 {
 	type Done = T;
 }
@@ -206,13 +206,13 @@ impl<R: Reducer<Item>, Item> Reducer<Option<Item>> for OptionReducer<R> {
 }
 impl<R: Reducer<Item>, Item> ReducerProcessSend<Option<Item>> for OptionReducer<R>
 where
-	R::Done: ProcessSend + 'static,
+	R::Done: ProcessSend,
 {
 	type Done = Option<R::Done>;
 }
 impl<R: Reducer<Item>, Item> ReducerSend<Option<Item>> for OptionReducer<R>
 where
-	R::Done: Send + 'static,
+	R::Done: Send,
 {
 	type Done = Option<R::Done>;
 }
@@ -254,15 +254,15 @@ impl<R: Reducer<Item>, E, Item> Reducer<Result<Item, E>> for ResultReducer<R, E>
 }
 impl<R: Reducer<Item>, E, Item> ReducerProcessSend<Result<Item, E>> for ResultReducer<R, E>
 where
-	R::Done: ProcessSend + 'static,
-	E: ProcessSend + 'static,
+	R::Done: ProcessSend,
+	E: ProcessSend,
 {
 	type Done = Result<R::Done, E>;
 }
 impl<R: Reducer<Item>, E, Item> ReducerSend<Result<Item, E>> for ResultReducer<R, E>
 where
-	R::Done: Send + 'static,
-	E: Send + 'static,
+	R::Done: Send,
+	E: Send,
 {
 	type Done = Result<R::Done, E>;
 }
@@ -291,7 +291,7 @@ impl<R: Sink<Item>, E, Item> Sink<Result<Item, E>> for ResultReducerAsync<R, E> 
 
 impl<T> FromParallelStream<T> for Vec<T>
 where
-	T: Send + 'static,
+	T: Send,
 {
 	type ReduceA = PushReducer<T, Self>;
 	type ReduceC = ExtendReducer<Self>;
@@ -303,7 +303,7 @@ where
 
 impl<T> FromParallelStream<T> for VecDeque<T>
 where
-	T: Send + 'static,
+	T: Send,
 {
 	type ReduceA = PushReducer<T, Vec<T>>;
 	type ReduceC = IntoReducer<ExtendReducer<Vec<T>>, Self>;
@@ -315,7 +315,7 @@ where
 
 impl<T: Ord> FromParallelStream<T> for BinaryHeap<T>
 where
-	T: Send + 'static,
+	T: Send,
 {
 	type ReduceA = PushReducer<T, Vec<T>>;
 	type ReduceC = IntoReducer<ExtendReducer<Vec<T>>, Self>;
@@ -327,7 +327,7 @@ where
 
 impl<T> FromParallelStream<T> for LinkedList<T>
 where
-	T: Send + 'static,
+	T: Send,
 {
 	type ReduceA = PushReducer<T, Self>;
 	type ReduceC = ExtendReducer<Self>;
@@ -339,8 +339,8 @@ where
 
 impl<T, S> FromParallelStream<T> for HashSet<T, S>
 where
-	T: Eq + Hash + Send + 'static,
-	S: BuildHasher + Default + Send + 'static,
+	T: Eq + Hash + Send,
+	S: BuildHasher + Default + Send,
 {
 	type ReduceA = PushReducer<T, Self>;
 	type ReduceC = ExtendReducer<Self>;
@@ -352,9 +352,9 @@ where
 
 impl<K, V, S> FromParallelStream<(K, V)> for HashMap<K, V, S>
 where
-	K: Eq + Hash + Send + 'static,
-	V: Send + 'static,
-	S: BuildHasher + Default + Send + 'static,
+	K: Eq + Hash + Send,
+	V: Send,
+	S: BuildHasher + Default + Send,
 {
 	type ReduceA = PushReducer<(K, V), Self>;
 	type ReduceC = ExtendReducer<Self>;
@@ -366,7 +366,7 @@ where
 
 impl<T> FromParallelStream<T> for BTreeSet<T>
 where
-	T: Ord + Send + 'static,
+	T: Ord + Send,
 {
 	type ReduceA = PushReducer<T, Self>;
 	type ReduceC = ExtendReducer<Self>;
@@ -378,8 +378,8 @@ where
 
 impl<K, V> FromParallelStream<(K, V)> for BTreeMap<K, V>
 where
-	K: Ord + Send + 'static,
-	V: Send + 'static,
+	K: Ord + Send,
+	V: Send,
 {
 	type ReduceA = PushReducer<(K, V), Self>;
 	type ReduceC = ExtendReducer<Self>;
@@ -428,7 +428,7 @@ impl<T, C: FromParallelStream<T>> FromParallelStream<Option<T>> for Option<C> {
 
 impl<T, C: FromParallelStream<T>, E> FromParallelStream<Result<T, E>> for Result<C, E>
 where
-	E: Send + 'static,
+	E: Send,
 {
 	type ReduceA = ResultReducer<C::ReduceA, E>;
 	type ReduceC = ResultReducer<C::ReduceC, E>;
@@ -441,7 +441,7 @@ where
 
 impl<T> FromDistributedStream<T> for Vec<T>
 where
-	T: ProcessSend + 'static,
+	T: ProcessSend,
 {
 	type ReduceA = PushReducer<T, Self>;
 	type ReduceB = ExtendReducer<Self>;
@@ -454,7 +454,7 @@ where
 
 impl<T> FromDistributedStream<T> for VecDeque<T>
 where
-	T: ProcessSend + 'static,
+	T: ProcessSend,
 {
 	type ReduceA = PushReducer<T, Vec<T>>;
 	type ReduceB = ExtendReducer<Vec<T>>;
@@ -467,7 +467,7 @@ where
 
 impl<T: Ord> FromDistributedStream<T> for BinaryHeap<T>
 where
-	T: ProcessSend + 'static,
+	T: ProcessSend,
 {
 	type ReduceA = PushReducer<T, Vec<T>>;
 	type ReduceB = ExtendReducer<Vec<T>>;
@@ -480,7 +480,7 @@ where
 
 impl<T> FromDistributedStream<T> for LinkedList<T>
 where
-	T: ProcessSend + 'static,
+	T: ProcessSend,
 {
 	type ReduceA = PushReducer<T, Self>;
 	type ReduceB = ExtendReducer<Self>;
@@ -493,8 +493,8 @@ where
 
 impl<T, S> FromDistributedStream<T> for HashSet<T, S>
 where
-	T: Eq + Hash + ProcessSend + 'static,
-	S: BuildHasher + Default + Send + 'static,
+	T: Eq + Hash + ProcessSend,
+	S: BuildHasher + Default + Send,
 {
 	type ReduceA = PushReducer<T, Self>;
 	type ReduceB = ExtendReducer<Self>;
@@ -507,9 +507,9 @@ where
 
 impl<K, V, S> FromDistributedStream<(K, V)> for HashMap<K, V, S>
 where
-	K: Eq + Hash + ProcessSend + 'static,
-	V: ProcessSend + 'static,
-	S: BuildHasher + Default + Send + 'static,
+	K: Eq + Hash + ProcessSend,
+	V: ProcessSend,
+	S: BuildHasher + Default + Send,
 {
 	type ReduceA = PushReducer<(K, V), Self>;
 	type ReduceB = ExtendReducer<Self>;
@@ -522,7 +522,7 @@ where
 
 impl<T> FromDistributedStream<T> for BTreeSet<T>
 where
-	T: Ord + ProcessSend + 'static,
+	T: Ord + ProcessSend,
 {
 	type ReduceA = PushReducer<T, Self>;
 	type ReduceB = ExtendReducer<Self>;
@@ -535,8 +535,8 @@ where
 
 impl<K, V> FromDistributedStream<(K, V)> for BTreeMap<K, V>
 where
-	K: Ord + ProcessSend + 'static,
-	V: ProcessSend + 'static,
+	K: Ord + ProcessSend,
+	V: ProcessSend,
 {
 	type ReduceA = PushReducer<(K, V), Self>;
 	type ReduceB = ExtendReducer<Self>;
@@ -590,7 +590,7 @@ impl<T, C: FromDistributedStream<T>> FromDistributedStream<Option<T>> for Option
 
 impl<T, C: FromDistributedStream<T>, E> FromDistributedStream<Result<T, E>> for Result<C, E>
 where
-	E: ProcessSend + 'static,
+	E: ProcessSend,
 {
 	type ReduceA = ResultReducer<C::ReduceA, E>;
 	type ReduceB = ResultReducer<C::ReduceB, E>;

--- a/amadeus-core/src/par_sink/combine.rs
+++ b/amadeus-core/src/par_sink/combine.rs
@@ -46,8 +46,8 @@ pub struct Combine<P, F> {
 impl_par_dist! {
 	impl<P: ParallelPipe<Item>, Item, F> ParallelSink<Item> for Combine<P, F>
 	where
-		F: FnMut<(P::Output, P::Output), Output = P::Output> + Clone + Send + 'static,
-		P::Output: Send + 'static,
+		F: FnMut<(P::Output, P::Output), Output = P::Output> + Clone + Send,
+		P::Output: Send,
 	{
 		combiner_par_sink!(ReduceFn<F, P::Output>, self, ReduceFn::new(self.f));
 	}

--- a/amadeus-core/src/par_sink/fold.rs
+++ b/amadeus-core/src/par_sink/fold.rs
@@ -22,9 +22,9 @@ pub struct Fold<P, ID, F, B> {
 impl_par_dist! {
 	impl<P: ParallelPipe<Item>, Item, ID, F, B> ParallelSink<Item> for Fold<P, ID, F, B>
 	where
-		ID: FnMut<(), Output = B> + Clone + Send + 'static,
-		F: FnMut<(B, Either<P::Output, B>), Output = B> + Clone + Send + 'static,
-		B: Send + 'static,
+		ID: FnMut<(), Output = B> + Clone + Send,
+		F: FnMut<(B, Either<P::Output, B>), Output = B> + Clone + Send,
+		B: Send,
 	{
 		folder_par_sink!(FoldFolder<P::Output, ID, F, B, StepA>, FoldFolder<P::Output, ID, F, B, StepB>, self, FoldFolder::new(self.identity.clone(), self.op.clone()), FoldFolder::new(self.identity, self.op));
 	}

--- a/amadeus-core/src/par_sink/folder.rs
+++ b/amadeus-core/src/par_sink/folder.rs
@@ -95,14 +95,14 @@ where
 impl<Item, F> ReducerProcessSend<Item> for FolderSyncReducer<Item, F>
 where
 	F: FolderSync<Item>,
-	F::Done: ProcessSend + 'static,
+	F::Done: ProcessSend,
 {
 	type Done = F::Done;
 }
 impl<Item, F> ReducerSend<Item> for FolderSyncReducer<Item, F>
 where
 	F: FolderSync<Item>,
-	F::Done: Send + 'static,
+	F::Done: Send,
 {
 	type Done = F::Done;
 }

--- a/amadeus-core/src/par_sink/for_each.rs
+++ b/amadeus-core/src/par_sink/for_each.rs
@@ -22,7 +22,7 @@ pub struct ForEach<P, F> {
 
 impl<P: ParallelPipe<Item>, Item, F> ParallelSink<Item> for ForEach<P, F>
 where
-	F: FnMut<(P::Output,), Output = ()> + Clone + Send + 'static,
+	F: FnMut<(P::Output,), Output = ()> + Clone + Send,
 {
 	type Done = ();
 	type Pipe = P;
@@ -39,7 +39,7 @@ where
 }
 impl<P: DistributedPipe<Item>, Item, F> DistributedSink<Item> for ForEach<P, F>
 where
-	F: FnMut<(P::Output,), Output = ()> + Clone + ProcessSend + 'static,
+	F: FnMut<(P::Output,), Output = ()> + Clone + ProcessSend,
 {
 	type Done = ();
 	type Pipe = P;

--- a/amadeus-core/src/par_sink/group_by.rs
+++ b/amadeus-core/src/par_sink/group_by.rs
@@ -28,11 +28,11 @@ pub struct GroupBy<A, B> {
 impl<A: ParallelPipe<Item, Output = (T, U)>, B: ParallelSink<U>, Item, T, U> ParallelSink<Item>
 	for GroupBy<A, B>
 where
-	T: Eq + Hash + Send + 'static,
-	<B::Pipe as ParallelPipe<U>>::Task: Clone + Send + 'static,
-	B::ReduceA: Clone + Send + 'static,
+	T: Eq + Hash + Send,
+	<B::Pipe as ParallelPipe<U>>::Task: Clone + Send,
+	B::ReduceA: Clone + Send,
 	B::ReduceC: Clone,
-	B::Done: Send + 'static,
+	B::Done: Send,
 {
 	type Done = IndexMap<T, B::Done>;
 	type Pipe = A;
@@ -56,12 +56,12 @@ where
 impl<A: DistributedPipe<Item, Output = (T, U)>, B: DistributedSink<U>, Item, T, U>
 	DistributedSink<Item> for GroupBy<A, B>
 where
-	T: Eq + Hash + ProcessSend + 'static,
-	<B::Pipe as DistributedPipe<U>>::Task: Clone + ProcessSend + 'static,
-	B::ReduceA: Clone + ProcessSend + 'static,
+	T: Eq + Hash + ProcessSend,
+	<B::Pipe as DistributedPipe<U>>::Task: Clone + ProcessSend,
+	B::ReduceA: Clone + ProcessSend,
 	B::ReduceB: Clone,
 	B::ReduceC: Clone,
-	B::Done: ProcessSend + 'static,
+	B::Done: ProcessSend,
 {
 	type Done = IndexMap<T, B::Done>;
 	type Pipe = A;
@@ -115,8 +115,8 @@ impl<P, R, T, U> ReducerProcessSend<(T, U)> for GroupByReducerA<P, R, T, U>
 where
 	P: PipeTask<U>,
 	R: Reducer<P::Output> + Clone,
-	T: Eq + Hash + ProcessSend + 'static,
-	R::Done: ProcessSend + 'static,
+	T: Eq + Hash + ProcessSend,
+	R::Done: ProcessSend,
 {
 	type Done = IndexMap<T, R::Done>;
 }
@@ -124,8 +124,8 @@ impl<P, R, T, U> ReducerSend<(T, U)> for GroupByReducerA<P, R, T, U>
 where
 	P: PipeTask<U>,
 	R: Reducer<P::Output> + Clone,
-	T: Eq + Hash + Send + 'static,
-	R::Done: Send + 'static,
+	T: Eq + Hash + Send,
+	R::Done: Send,
 {
 	type Done = IndexMap<T, R::Done>;
 }
@@ -263,16 +263,16 @@ where
 impl<R, T, U> ReducerProcessSend<IndexMap<T, U>> for GroupByReducerB<R, T, U>
 where
 	R: Reducer<U> + Clone,
-	T: Eq + Hash + ProcessSend + 'static,
-	R::Done: ProcessSend + 'static,
+	T: Eq + Hash + ProcessSend,
+	R::Done: ProcessSend,
 {
 	type Done = IndexMap<T, R::Done>;
 }
 impl<R, T, U> ReducerSend<IndexMap<T, U>> for GroupByReducerB<R, T, U>
 where
 	R: Reducer<U> + Clone,
-	T: Eq + Hash + Send + 'static,
-	R::Done: Send + 'static,
+	T: Eq + Hash + Send,
+	R::Done: Send,
 {
 	type Done = IndexMap<T, R::Done>;
 }

--- a/amadeus-core/src/par_sink/histogram.rs
+++ b/amadeus-core/src/par_sink/histogram.rs
@@ -18,7 +18,7 @@ pub struct Histogram<P> {
 impl_par_dist! {
 	impl<P: ParallelPipe<Item>, Item> ParallelSink<Item> for Histogram<P>
 	where
-		P::Output: Hash + Ord + Send + 'static,
+		P::Output: Hash + Ord + Send,
 	{
 		folder_par_sink!(HistogramFolder<P::Output, StepA>, HistogramFolder<P::Output, StepB>, self, HistogramFolder::new(), HistogramFolder::new());
 	}

--- a/amadeus-core/src/par_sink/max.rs
+++ b/amadeus-core/src/par_sink/max.rs
@@ -14,7 +14,7 @@ pub struct Max<P> {
 impl_par_dist! {
 	impl<P: ParallelPipe<Item>, Item> ParallelSink<Item> for Max<P>
 	where
-		P::Output: Ord + Send + 'static,
+		P::Output: Ord + Send,
 	{
 		combiner_par_sink!(combine::Max<P::Output>, self, combine::Max::new());
 	}
@@ -31,9 +31,8 @@ impl_par_dist! {
 	where
 		F: for<'a, 'b> FnMut<(&'a P::Output, &'b P::Output), Output = Ordering>
 			+ Clone
-			+ Send
-			+ 'static,
-		P::Output: Send + 'static,
+			+ Send,
+		P::Output: Send,
 	{
 		combiner_par_sink!(combine::MaxBy<P::Output,F>, self, combine::MaxBy::new(self.f));
 	}
@@ -48,9 +47,9 @@ pub struct MaxByKey<P, F> {
 impl_par_dist! {
 	impl<P: ParallelPipe<Item>, Item, F, B> ParallelSink<Item> for MaxByKey<P, F>
 	where
-		F: for<'a> FnMut<(&'a P::Output,), Output = B> + Clone + Send + 'static,
-		B: Ord + 'static,
-		P::Output: Send + 'static,
+		F: for<'a> FnMut<(&'a P::Output,), Output = B> + Clone + Send,
+		B: Ord,
+		P::Output: Send,
 	{
 		combiner_par_sink!(combine::MaxByKey<P::Output,F, B>, self, combine::MaxByKey::new(self.f));
 	}
@@ -64,7 +63,7 @@ pub struct Min<P> {
 impl_par_dist! {
 	impl<P: ParallelPipe<Item>, Item> ParallelSink<Item> for Min<P>
 	where
-		P::Output: Ord + Send + 'static,
+		P::Output: Ord + Send,
 	{
 		combiner_par_sink!(combine::Min<P::Output>, self, combine::Min::new());
 	}
@@ -81,9 +80,8 @@ impl_par_dist! {
 	where
 		F: for<'a, 'b> FnMut<(&'a P::Output, &'b P::Output), Output = Ordering>
 			+ Clone
-			+ Send
-			+ 'static,
-		P::Output: Send + 'static,
+			+ Send,
+		P::Output: Send,
 	{
 		combiner_par_sink!(combine::MinBy<P::Output,F>, self, combine::MinBy::new(self.f));
 	}
@@ -98,9 +96,9 @@ pub struct MinByKey<P, F> {
 impl_par_dist! {
 	impl<P: ParallelPipe<Item>, Item, F, B> ParallelSink<Item> for MinByKey<P, F>
 	where
-		F: for<'a> FnMut<(&'a P::Output,), Output = B> + Clone + Send + 'static,
-		B: Ord + 'static,
-		P::Output: Send + 'static,
+		F: for<'a> FnMut<(&'a P::Output,), Output = B> + Clone + Send,
+		B: Ord,
+		P::Output: Send,
 	{
 		combiner_par_sink!(combine::MinByKey<P::Output,F, B>, self, combine::MinByKey::new(self.f));
 	}

--- a/amadeus-core/src/par_sink/sample.rs
+++ b/amadeus-core/src/par_sink/sample.rs
@@ -20,7 +20,7 @@ pub struct SampleUnstable<P> {
 impl_par_dist! {
 	impl<P: ParallelPipe<Item>, Item> ParallelSink<Item> for SampleUnstable<P>
 	where
-		P::Output: Send + 'static,
+		P::Output: Send,
 	{
 		folder_par_sink!(
 			SampleUnstableFolder,
@@ -60,7 +60,7 @@ pub struct MostFrequent<P> {
 impl_par_dist! {
 	impl<P: ParallelPipe<Item>, Item> ParallelSink<Item> for MostFrequent<P>
 	where
-		P::Output: Clone + Hash + Eq + Send + 'static,
+		P::Output: Clone + Hash + Eq + Send,
 	{
 		folder_par_sink!(
 			MostFrequentFolder,
@@ -81,7 +81,7 @@ pub struct MostFrequentFolder {
 
 impl<Item> FolderSync<Item> for MostFrequentFolder
 where
-	Item: Clone + Hash + Eq + Send + 'static,
+	Item: Clone + Hash + Eq + Send,
 {
 	type Done = Top<Item, usize>;
 
@@ -106,8 +106,8 @@ pub struct MostDistinct<P> {
 impl_par_dist! {
 	impl<P: ParallelPipe<Item, Output = (A, B)>, Item, A, B> ParallelSink<Item> for MostDistinct<P>
 	where
-		A: Clone + Hash + Eq + Send + 'static,
-		B: Hash + 'static,
+		A: Clone + Hash + Eq + Send,
+		B: Hash,
 	{
 		folder_par_sink!(
 			MostDistinctFolder,
@@ -134,8 +134,8 @@ pub struct MostDistinctFolder {
 
 impl<A, B> FolderSync<(A, B)> for MostDistinctFolder
 where
-	A: Clone + Hash + Eq + Send + 'static,
-	B: Hash + 'static,
+	A: Clone + Hash + Eq + Send,
+	B: Hash,
 {
 	type Done = Top<A, HyperLogLogMagnitude<B>>;
 

--- a/amadeus-core/src/par_sink/sum.rs
+++ b/amadeus-core/src/par_sink/sum.rs
@@ -16,7 +16,7 @@ pub struct Sum<P, B> {
 impl_par_dist! {
 	impl<P: ParallelPipe<Item>, Item, B> ParallelSink<Item> for Sum<P, B>
 	where
-		B: iter::Sum<P::Output> + iter::Sum<B> + Send + 'static,
+		B: iter::Sum<P::Output> + iter::Sum<B> + Send,
 	{
 		folder_par_sink!(
 			SumFolder<B>,

--- a/amadeus-core/src/par_sink/tuple.rs
+++ b/amadeus-core/src/par_sink/tuple.rs
@@ -213,10 +213,10 @@ macro_rules! impl_tuple {
 				}
 			}
 		}
-		impl<$($t: Reducer<$s>,)* $($s,)*> ReducerProcessSend<$enum<$($s,)*>> for $reducea<$($t,)*> where $($t::Done: ProcessSend + 'static,)* {
+		impl<$($t: Reducer<$s>,)* $($s,)*> ReducerProcessSend<$enum<$($s,)*>> for $reducea<$($t,)*> where $($t::Done: ProcessSend,)* {
 			type Done = ($($t::Done,)*);
 		}
-		impl<$($t: Reducer<$s>,)* $($s,)*> ReducerSend<$enum<$($s,)*>> for $reducea<$($t,)*> where $($t::Done: Send + 'static,)* {
+		impl<$($t: Reducer<$s>,)* $($s,)*> ReducerSend<$enum<$($s,)*>> for $reducea<$($t,)*> where $($t::Done: Send,)* {
 			type Done = ($($t::Done,)*);
 		}
 		#[pin_project]

--- a/amadeus-core/src/par_stream.rs
+++ b/amadeus-core/src/par_stream.rs
@@ -56,7 +56,7 @@ macro_rules! stream {
 			#[inline]
 			fn inspect<F>(self, f: F) -> Inspect<Self, F>
 			where
-				F: $fns::FnMut(&Self::Item) + Clone + $send + 'static,
+				F: $fns::FnMut(&Self::Item) + Clone + $send,
 				Self: Sized,
 			{
 				$assert_stream(Inspect::new(self, f))
@@ -65,7 +65,7 @@ macro_rules! stream {
 			#[inline]
 			fn update<F>(self, f: F) -> Update<Self, F>
 			where
-				F: $fns::FnMut(&mut Self::Item) + Clone + $send + 'static,
+				F: $fns::FnMut(&mut Self::Item) + Clone + $send,
 				Self: Sized,
 			{
 				$assert_stream(Update::new(self, f))
@@ -74,7 +74,7 @@ macro_rules! stream {
 			#[inline]
 			fn map<B, F>(self, f: F) -> Map<Self, F>
 			where
-				F: $fns::FnMut(Self::Item) -> B + Clone + $send + 'static,
+				F: $fns::FnMut(Self::Item) -> B + Clone + $send,
 				Self: Sized,
 			{
 				$assert_stream(Map::new(self, f))
@@ -83,7 +83,7 @@ macro_rules! stream {
 			#[inline]
 			fn flat_map<B, F>(self, f: F) -> FlatMap<Self, F>
 			where
-				F: $fns::FnMut(Self::Item) -> B + Clone + $send + 'static,
+				F: $fns::FnMut(Self::Item) -> B + Clone + $send,
 				B: Stream,
 				Self: Sized,
 			{
@@ -93,7 +93,7 @@ macro_rules! stream {
 			#[inline]
 			fn filter<F>(self, f: F) -> Filter<Self, F>
 			where
-				F: $fns::FnMut(&Self::Item) -> bool + Clone + $send + 'static,
+				F: $fns::FnMut(&Self::Item) -> bool + Clone + $send,
 				Self: Sized,
 			{
 				$assert_stream(Filter::new(self, f))
@@ -112,9 +112,9 @@ macro_rules! stream {
 			async fn for_each<P, F>(self, pool: &P, f: F)
 			where
 				P: $pool,
-				F: $fns::FnMut(Self::Item) + Clone + $send + 'static,
-				Self::Item: 'static,
-				Self::Task: 'static,
+				F: $fns::FnMut(Self::Item) + Clone + $send,
+
+
 				Self: Sized,
 			{
 				self.pipe(pool, $pipe::<Self::Item>::for_each(Identity, f))
@@ -125,11 +125,11 @@ macro_rules! stream {
 			async fn fold<P, ID, F, B>(self, pool: &P, identity: ID, op: F) -> B
 			where
 				P: $pool,
-				ID: $fns::FnMut() -> B + Clone + $send + 'static,
-				F: $fns::FnMut(B, Either<Self::Item, B>) -> B + Clone + $send + 'static,
-				B: $send + 'static,
-				Self::Item: 'static,
-				Self::Task: 'static,
+				ID: $fns::FnMut() -> B + Clone + $send,
+				F: $fns::FnMut(B, Either<Self::Item, B>) -> B + Clone + $send,
+				B: $send,
+
+
 				Self: Sized,
 			{
 				self.pipe(
@@ -143,8 +143,8 @@ macro_rules! stream {
 			async fn histogram<P>(self, pool: &P) -> Vec<(Self::Item, usize)>
 			where
 				P: $pool,
-				Self::Item: Hash + Ord + $send + 'static,
-				Self::Task: 'static,
+				Self::Item: Hash + Ord + $send,
+
 				Self: Sized,
 			{
 				self.pipe(pool, $pipe::<Self::Item>::histogram(Identity))
@@ -155,8 +155,8 @@ macro_rules! stream {
 			async fn count<P>(self, pool: &P) -> usize
 			where
 				P: $pool,
-				Self::Item: 'static,
-				Self::Task: 'static,
+
+
 				Self: Sized,
 			{
 				self.pipe(pool, $pipe::<Self::Item>::count(Identity))
@@ -167,9 +167,9 @@ macro_rules! stream {
 			async fn sum<P, S>(self, pool: &P) -> S
 			where
 				P: $pool,
-				S: iter::Sum<Self::Item> + iter::Sum<S> + $send + 'static,
-				Self::Item: 'static,
-				Self::Task: 'static,
+				S: iter::Sum<Self::Item> + iter::Sum<S> + $send,
+
+
 				Self: Sized,
 			{
 				self.pipe(pool, $pipe::<Self::Item>::sum(Identity))
@@ -180,9 +180,9 @@ macro_rules! stream {
 			async fn combine<P, F>(self, pool: &P, f: F) -> Option<Self::Item>
 			where
 				P: $pool,
-				F: $fns::FnMut(Self::Item, Self::Item) -> Self::Item + Clone + $send + 'static,
-				Self::Item: $send + 'static,
-				Self::Task: 'static,
+				F: $fns::FnMut(Self::Item, Self::Item) -> Self::Item + Clone + $send,
+				Self::Item: $send,
+
 				Self: Sized,
 			{
 				self.pipe(pool, $pipe::<Self::Item>::combine(Identity, f))
@@ -193,8 +193,8 @@ macro_rules! stream {
 			async fn max<P>(self, pool: &P) -> Option<Self::Item>
 			where
 				P: $pool,
-				Self::Item: Ord + $send + 'static,
-				Self::Task: 'static,
+				Self::Item: Ord + $send,
+
 				Self: Sized,
 			{
 				self.pipe(pool, $pipe::<Self::Item>::max(Identity))
@@ -205,9 +205,9 @@ macro_rules! stream {
 			async fn max_by<P, F>(self, pool: &P, f: F) -> Option<Self::Item>
 			where
 				P: $pool,
-				F: $fns::FnMut(&Self::Item, &Self::Item) -> Ordering + Clone + $send + 'static,
-				Self::Item: $send + 'static,
-				Self::Task: 'static,
+				F: $fns::FnMut(&Self::Item, &Self::Item) -> Ordering + Clone + $send,
+				Self::Item: $send,
+
 				Self: Sized,
 			{
 				self.pipe(pool, $pipe::<Self::Item>::max_by(Identity, f))
@@ -218,10 +218,10 @@ macro_rules! stream {
 			async fn max_by_key<P, F, B>(self, pool: &P, f: F) -> Option<Self::Item>
 			where
 				P: $pool,
-				F: $fns::FnMut(&Self::Item) -> B + Clone + $send + 'static,
-				B: Ord + 'static,
-				Self::Item: $send + 'static,
-				Self::Task: 'static,
+				F: $fns::FnMut(&Self::Item) -> B + Clone + $send,
+				B: Ord,
+				Self::Item: $send,
+
 				Self: Sized,
 			{
 				self.pipe(pool, $pipe::<Self::Item>::max_by_key(Identity, f))
@@ -232,8 +232,8 @@ macro_rules! stream {
 			async fn min<P>(self, pool: &P) -> Option<Self::Item>
 			where
 				P: $pool,
-				Self::Item: Ord + $send + 'static,
-				Self::Task: 'static,
+				Self::Item: Ord + $send,
+
 				Self: Sized,
 			{
 				self.pipe(pool, $pipe::<Self::Item>::min(Identity))
@@ -244,9 +244,9 @@ macro_rules! stream {
 			async fn min_by<P, F>(self, pool: &P, f: F) -> Option<Self::Item>
 			where
 				P: $pool,
-				F: $fns::FnMut(&Self::Item, &Self::Item) -> Ordering + Clone + $send + 'static,
-				Self::Item: $send + 'static,
-				Self::Task: 'static,
+				F: $fns::FnMut(&Self::Item, &Self::Item) -> Ordering + Clone + $send,
+				Self::Item: $send,
+
 				Self: Sized,
 			{
 				self.pipe(pool, $pipe::<Self::Item>::min_by(Identity, f))
@@ -257,10 +257,10 @@ macro_rules! stream {
 			async fn min_by_key<P, F, B>(self, pool: &P, f: F) -> Option<Self::Item>
 			where
 				P: $pool,
-				F: $fns::FnMut(&Self::Item) -> B + Clone + $send + 'static,
-				B: Ord + 'static,
-				Self::Item: $send + 'static,
-				Self::Task: 'static,
+				F: $fns::FnMut(&Self::Item) -> B + Clone + $send,
+				B: Ord,
+				Self::Item: $send,
+
 				Self: Sized,
 			{
 				self.pipe(pool, $pipe::<Self::Item>::min_by_key(Identity, f))
@@ -273,8 +273,8 @@ macro_rules! stream {
 			) -> ::streaming_algorithms::Top<Self::Item, usize>
 			where
 				P: $pool,
-				Self::Item: Hash + Eq + Clone + $send + 'static,
-				Self::Task: 'static,
+				Self::Item: Hash + Eq + Clone + $send,
+
 				Self: Sized,
 			{
 				self.pipe(
@@ -291,9 +291,9 @@ macro_rules! stream {
 			where
 				P: $pool,
 				Self: $stream<Item = (A, B)> + Sized,
-				A: Hash + Eq + Clone + $send + 'static,
-				B: Hash + 'static,
-				Self::Task: 'static,
+				A: Hash + Eq + Clone + $send,
+				B: Hash,
+
 			{
 				self.pipe(
 					pool,
@@ -314,8 +314,8 @@ macro_rules! stream {
 			) -> ::streaming_algorithms::SampleUnstable<Self::Item>
 			where
 				P: $pool,
-				Self::Item: $send + 'static,
-				Self::Task: 'static,
+				Self::Item: $send,
+
 				Self: Sized,
 			{
 				self.pipe(
@@ -329,9 +329,9 @@ macro_rules! stream {
 			async fn all<P, F>(self, pool: &P, f: F) -> bool
 			where
 				P: $pool,
-				F: $fns::FnMut(Self::Item) -> bool + Clone + $send + 'static,
-				Self::Item: 'static,
-				Self::Task: 'static,
+				F: $fns::FnMut(Self::Item) -> bool + Clone + $send,
+
+
 				Self: Sized,
 			{
 				self.pipe(pool, $pipe::<Self::Item>::all(Identity, f))
@@ -342,9 +342,9 @@ macro_rules! stream {
 			async fn any<P, F>(self, pool: &P, f: F) -> bool
 			where
 				P: $pool,
-				F: $fns::FnMut(Self::Item) -> bool + Clone + $send + 'static,
-				Self::Item: 'static,
-				Self::Task: 'static,
+				F: $fns::FnMut(Self::Item) -> bool + Clone + $send,
+
+
 				Self: Sized,
 			{
 				self.pipe(pool, $pipe::<Self::Item>::any(Identity, f))
@@ -360,12 +360,15 @@ macro_rules! stream {
 }
 
 stream!(ParallelStream ParallelPipe ParallelSink FromParallelStream IntoParallelStream into_par_stream ParStream ThreadPool Send ops assert_parallel_stream {
-	async fn reduce<P, B, R1, R3>(mut self, pool: &P, reduce_a: R1, reduce_c: R3) -> B
+	async fn reduce_owned<P, B, R1, R3>(mut self, pool: &P, reduce_a: R1, reduce_c: R3) -> B
 	where
 		P: ThreadPool,
 		R1: ReducerSend<Self::Item> + Clone + Send + 'static,
 		R3: Reducer<<R1 as ReducerSend<Self::Item>>::Done, Done = B>,
+
 		Self::Task: 'static,
+		<R1 as Reducer<Self::Item>>::Done: 'static,
+
 		Self: Sized,
 	{
 		let self_ = self;
@@ -417,18 +420,19 @@ stream!(ParallelStream ParallelPipe ParallelSink FromParallelStream IntoParallel
 			.filter(|tasks| !tasks.is_empty())
 			.map(|tasks| {
 				let reduce_a = reduce_a.clone();
-				pool.spawn(move || async move {
+				let spawn = move || async move {
 					let sink = reduce_a.into_async();
 					pin_mut!(sink);
 					// this is faster than stream::iter(tasks.into_iter().map(StreamTask::into_async)).flatten().sink(sink).await
 					for task in tasks.into_iter().map(StreamTask::into_async) {
-							pin_mut!(task);
-							if let Some(ret) = sink.send_all(&mut task).await {
-									return ret;
-							}
+						pin_mut!(task);
+						if let Some(ret) = sink.send_all(&mut task).await {
+							return ret;
+						}
 					}
 					sink.done().await
-				})
+				};
+				pool.spawn(spawn)
 			})
 			.collect::<futures::stream::FuturesUnordered<_>>();
 		let stream = handles.map(|item| {
@@ -436,16 +440,95 @@ stream!(ParallelStream ParallelPipe ParallelSink FromParallelStream IntoParallel
 		});
 		let reduce_c = reduce_c.into_async();
 		pin_mut!(reduce_c);
-		stream.sink(reduce_c.as_mut()).await
+		stream.sink(reduce_c).await
+	}
+
+	async fn reduce<P, B, R1, R3>(mut self, pool: &P, reduce_a: R1, reduce_c: R3) -> B
+	where
+		P: ThreadPool,
+		R1: ReducerSend<Self::Item> + Clone + Send,
+		R3: Reducer<<R1 as ReducerSend<Self::Item>>::Done, Done = B>,
+
+		Self: Sized,
+	{
+		let self_ = self;
+		pin_mut!(self_);
+		// TODO: don't buffer tasks before sending. requires changes to ThreadPool
+		let mut tasks = (0..pool.threads()).map(|_| vec![]).collect::<Vec<_>>();
+		let mut allocated = 0;
+		'a: loop {
+			for i in 0..tasks.len() {
+				loop {
+					let (mut lower, _upper) = self_.size_hint();
+					if lower == 0 {
+						lower = 1;
+					}
+					let mut batch = (allocated + lower) / tasks.len();
+					if i < (allocated + lower) % tasks.len() {
+						batch += 1;
+					}
+					batch -= tasks[i].len();
+					if batch == 0 {
+						break;
+					}
+					for _ in 0..batch {
+						if let Some(task) = future::poll_fn(|cx| self_.as_mut().next_task(cx)).await {
+							tasks[i].push(task);
+							allocated += 1;
+						} else {
+							break 'a;
+						}
+					}
+				}
+			}
+		}
+		for (i, task) in tasks.iter().enumerate() {
+			let mut count = allocated / tasks.len();
+			if i < allocated % tasks.len() {
+				count += 1;
+			}
+			assert_eq!(
+				task.len(),
+				count,
+				"alloc: {:#?}",
+				tasks.iter().map(Vec::len).collect::<Vec<_>>()
+			);
+		}
+
+		let handles = tasks
+			.into_iter()
+			.filter(|tasks| !tasks.is_empty())
+			.map(|tasks| {
+				let reduce_a = reduce_a.clone();
+				let spawn = move || async move {
+					let sink = reduce_a.into_async();
+					pin_mut!(sink);
+					// this is faster than stream::iter(tasks.into_iter().map(StreamTask::into_async)).flatten().sink(sink).await
+					for task in tasks.into_iter().map(StreamTask::into_async) {
+						pin_mut!(task);
+						if let Some(ret) = sink.send_all(&mut task).await {
+							return ret;
+						}
+					}
+					sink.done().await
+				};
+				#[allow(unsafe_code)]
+				unsafe { pool.spawn_unchecked(spawn) }
+			})
+			.collect::<futures::stream::FuturesUnordered<_>>();
+		let stream = handles.map(|item| {
+			item.unwrap_or_else(|err| panic!("Amadeus: task '<unnamed>' panicked at '{}'", err))
+		});
+		let reduce_c = reduce_c.into_async();
+		pin_mut!(reduce_c);
+		let rt = tokio::runtime::Handle::current();
+		tokio::task::block_in_place(|| rt.block_on(stream.sink(reduce_c)))
 	}
 
 	async fn pipe<P, ParSink, A>(self, pool: &P, sink: ParSink) -> A
 	where
 		P: ThreadPool,
 		ParSink: ParallelSink<Self::Item, Done = A>,
-		<ParSink::Pipe as ParallelPipe<Self::Item>>::Task: 'static,
-		ParSink::ReduceA: 'static,
-		Self::Task: 'static,
 		Self: Sized,
 	{
 		let (iterator, reducer_a, reducer_b) = sink.reducers();
@@ -454,22 +537,14 @@ stream!(ParallelStream ParallelPipe ParallelSink FromParallelStream IntoParallel
 			.await
 	}
 
-	// These messy bounds are unfortunately necessary as requiring 'static in ParallelSink breaks sink_b being e.g. Identity.count()
 	async fn fork<P, ParSinkA, ParSinkB, A, B>(
 		self, pool: &P, sink_a: ParSinkA, sink_b: ParSinkB,
 	) -> (A, B)
 	where
 		P: ThreadPool,
 		ParSinkA: ParallelSink<Self::Item, Done = A>,
-		ParSinkB: for<'a> ParallelSink<&'a Self::Item, Done = B> + 'static,
-		<ParSinkA::Pipe as ParallelPipe<Self::Item>>::Task: 'static,
-		ParSinkA::ReduceA: 'static,
-		<ParSinkB as ParallelSink<&'static Self::Item>>::ReduceA: 'static,
-		<<ParSinkB as ParallelSink<&'static Self::Item>>::Pipe as ParallelPipe<
-			&'static Self::Item,
-		>>::Task: 'static,
+		ParSinkB: for<'a> ParallelSink<&'a Self::Item, Done = B>,
 		Self::Item: 'static,
-		Self::Task: 'static,
 		Self: Sized,
 	{
 		let (iterator_a, reducer_a_a, reducer_a_b) = sink_a.reducers();
@@ -486,14 +561,12 @@ stream!(ParallelStream ParallelPipe ParallelSink FromParallelStream IntoParallel
 	async fn group_by<P, S, A, B>(self, pool: &P, sink: S) -> IndexMap<A, S::Done>
 	where
 		P: ThreadPool,
-		A: Eq + Hash + Send + 'static,
-		B: 'static,
+		A: Eq + Hash + Send,
 		S: ParallelSink<B>,
-		<S::Pipe as ParallelPipe<B>>::Task: Clone + Send + 'static,
-		S::ReduceA: 'static,
+		<S::Pipe as ParallelPipe<B>>::Task: Clone + Send,
 		S::ReduceC: Clone,
-		S::Done: Send + 'static,
-		Self::Task: 'static,
+		S::Done: Send,
+
 		Self: ParallelStream<Item = (A, B)> + Sized,
 	{
 		self.pipe(pool, ParallelPipe::<Self::Item>::group_by(Identity, sink))
@@ -504,8 +577,8 @@ stream!(ParallelStream ParallelPipe ParallelSink FromParallelStream IntoParallel
 	where
 		P: ThreadPool,
 		B: FromParallelStream<Self::Item>,
-		B::ReduceA: Send + 'static,
-		Self::Task: 'static,
+		B::ReduceA: Send,
+
 		Self: Sized,
 	{
 		self.pipe(pool, ParallelPipe::<Self::Item>::collect(Identity))
@@ -519,16 +592,15 @@ stream!(DistributedStream DistributedPipe DistributedSink FromDistributedStream 
 	) -> B
 	where
 		P: ProcessPool,
-		R1: ReducerSend<Self::Item> + Clone + ProcessSend + 'static,
+		R1: ReducerSend<Self::Item> + Clone + ProcessSend,
 		R2: ReducerProcessSend<<R1 as ReducerSend<Self::Item>>::Done>
 			+ Clone
-			+ ProcessSend
-			+ 'static,
+			+ ProcessSend,
 		R3: Reducer<
 			<R2 as ReducerProcessSend<<R1 as ReducerSend<Self::Item>>::Done>>::Done,
 			Done = B,
 		>,
-		Self::Task: 'static,
+
 		Self: Sized,
 	{
 		let self_ = self;
@@ -581,7 +653,9 @@ stream!(DistributedStream DistributedPipe DistributedSink FromDistributedStream 
 			.map(|tasks| {
 				let reduce_b = reduce_b.clone();
 				let reduce_a = reduce_a.clone();
-				pool.spawn(FnOnce!(move |pool: &P::ThreadPool| {
+				let spawn = FnOnce!(move |pool: &P::ThreadPool| {
+					let reduce_b = reduce_b;
+					let reduce_a = reduce_a;
 					let mut process_tasks = tasks.into_iter();
 
 					let mut tasks = (0..pool.threads()).map(|_| vec![]).collect::<Vec<_>>();
@@ -629,18 +703,20 @@ stream!(DistributedStream DistributedPipe DistributedSink FromDistributedStream 
 						.filter(|tasks| !tasks.is_empty())
 						.map(|tasks| {
 							let reduce_a = reduce_a.clone();
-							pool.spawn(move || async move {
+							let spawn = move || async move {
 								let sink = reduce_a.into_async();
 								pin_mut!(sink);
 								// this is faster than stream::iter(tasks.into_iter().map(StreamTask::into_async)).flatten().sink(sink).await
 								for task in tasks.into_iter().map(StreamTask::into_async) {
-										pin_mut!(task);
-										if let Some(ret) = sink.send_all(&mut task).await {
-												return ret;
-										}
+									pin_mut!(task);
+									if let Some(ret) = sink.send_all(&mut task).await {
+										return ret;
+									}
 								}
 								sink.done().await
-							})
+							};
+							#[allow(unsafe_code)]
+							unsafe{pool.spawn_unchecked(spawn)}
 						})
 						.collect::<futures::stream::FuturesUnordered<_>>();
 
@@ -652,9 +728,12 @@ stream!(DistributedStream DistributedPipe DistributedSink FromDistributedStream 
 					let reduce_b = reduce_b.into_async();
 					async move {
 						pin_mut!(reduce_b);
-						stream.sink(reduce_b.as_mut()).await
+						// TODO: these currently can't be cancelled. when they can be, we'll need to block
+						stream.sink(reduce_b).await
 					}
-				}))
+				});
+				#[allow(unsafe_code)]
+				unsafe { pool.spawn_unchecked(spawn) }
 			})
 			.collect::<futures::stream::FuturesUnordered<_>>();
 		let stream = handles.map(|item| {
@@ -662,17 +741,14 @@ stream!(DistributedStream DistributedPipe DistributedSink FromDistributedStream 
 		});
 		let reduce_c = reduce_c.into_async();
 		pin_mut!(reduce_c);
-		stream.sink(reduce_c.as_mut()).await
+		let rt = tokio::runtime::Handle::current();
+		tokio::task::block_in_place(|| rt.block_on(stream.sink(reduce_c)))
 	}
 
 	async fn pipe<P, DistSink, A>(self, pool: &P, sink: DistSink) -> A
 	where
 		P: ProcessPool,
 		DistSink: DistributedSink<Self::Item, Done = A>,
-		<DistSink::Pipe as DistributedPipe<Self::Item>>::Task: 'static,
-		DistSink::ReduceA: 'static,
-		DistSink::ReduceB: 'static,
-		Self::Task: 'static,
 		Self: Sized,
 	{
 		let (iterator, reducer_a, reducer_b, reducer_c) = sink.reducers();
@@ -681,24 +757,14 @@ stream!(DistributedStream DistributedPipe DistributedSink FromDistributedStream 
 			.await
 	}
 
-	// These messy bounds are unfortunately necessary as requiring 'static in DistributedSink breaks sink_b being e.g. Identity.count()
 	async fn fork<P, DistSinkA, DistSinkB, A, B>(
 		self, pool: &P, sink_a: DistSinkA, sink_b: DistSinkB,
 	) -> (A, B)
 	where
 		P: ProcessPool,
 		DistSinkA: DistributedSink<Self::Item, Done = A>,
-		DistSinkB: for<'a> DistributedSink<&'a Self::Item, Done = B> + 'static,
-		<DistSinkA::Pipe as DistributedPipe<Self::Item>>::Task: 'static,
-		DistSinkA::ReduceA: 'static,
-		DistSinkA::ReduceB: 'static,
-		<DistSinkB as DistributedSink<&'static Self::Item>>::ReduceA: 'static,
-		<DistSinkB as DistributedSink<&'static Self::Item>>::ReduceB: 'static,
-		<<DistSinkB as DistributedSink<&'static Self::Item>>::Pipe as DistributedPipe<
-			&'static Self::Item,
-		>>::Task: 'static,
+		DistSinkB: for<'a> DistributedSink<&'a Self::Item, Done = B>,
 		Self::Item: 'static,
-		Self::Task: 'static,
 		Self: Sized,
 	{
 		let (iterator_a, reducer_a_a, reducer_a_b, reducer_a_c) = sink_a.reducers();
@@ -716,15 +782,12 @@ stream!(DistributedStream DistributedPipe DistributedSink FromDistributedStream 
 	async fn group_by<P, S, A, B>(self, pool: &P, sink: S) -> IndexMap<A, S::Done>
 	where
 		P: ProcessPool,
-		A: Eq + Hash + ProcessSend + 'static,
-		B: 'static,
+		A: Eq + Hash + ProcessSend,
 		S: DistributedSink<B>,
-		<S::Pipe as DistributedPipe<B>>::Task: Clone + ProcessSend + 'static,
-		S::ReduceA: 'static,
-		S::ReduceB: 'static,
+		<S::Pipe as DistributedPipe<B>>::Task: Clone + ProcessSend,
 		S::ReduceC: Clone,
-		S::Done: ProcessSend + 'static,
-		Self::Task: 'static,
+		S::Done: ProcessSend,
+
 		Self: DistributedStream<Item = (A, B)> + Sized,
 	{
 		self.pipe(
@@ -738,9 +801,9 @@ stream!(DistributedStream DistributedPipe DistributedSink FromDistributedStream 
 	where
 		P: ProcessPool,
 		B: FromDistributedStream<Self::Item>,
-		B::ReduceA: ProcessSend + 'static,
-		B::ReduceB: ProcessSend + 'static,
-		Self::Task: 'static,
+		B::ReduceA: ProcessSend,
+		B::ReduceB: ProcessSend,
+
 		Self: Sized,
 	{
 		self.pipe(pool, DistributedPipe::<Self::Item>::collect(Identity))

--- a/amadeus-core/src/par_stream/filter.rs
+++ b/amadeus-core/src/par_stream/filter.rs
@@ -20,7 +20,7 @@ pub struct Filter<P, F> {
 impl_par_dist! {
 	impl<P: ParallelStream, F> ParallelStream for Filter<P, F>
 	where
-		F: for<'a> FnMut<(&'a P::Item,), Output = bool> + Clone + Send + 'static,
+		F: for<'a> FnMut<(&'a P::Item,), Output = bool> + Clone + Send,
 	{
 		type Item = P::Item;
 		type Task = FilterTask<P::Task, F>;
@@ -42,7 +42,7 @@ impl_par_dist! {
 
 	impl<P: ParallelPipe<Input>, F, Input> ParallelPipe<Input> for Filter<P, F>
 	where
-		F: for<'a> FnMut<(&'a P::Output,), Output = bool> + Clone + Send + 'static,
+		F: for<'a> FnMut<(&'a P::Output,), Output = bool> + Clone + Send,
 	{
 		type Output = P::Output;
 		type Task = FilterTask<P::Task, F>;

--- a/amadeus-core/src/par_stream/flat_map.rs
+++ b/amadeus-core/src/par_stream/flat_map.rs
@@ -21,7 +21,7 @@ pub struct FlatMap<P, F> {
 impl_par_dist! {
 	impl<P: ParallelStream, F, R: Stream> ParallelStream for FlatMap<P, F>
 	where
-		F: FnMut<(P::Item,), Output = R> + Clone + Send + 'static,
+		F: FnMut<(P::Item,), Output = R> + Clone + Send,
 	{
 		type Item = R::Item;
 		type Task = FlatMapTask<P::Task, F>;
@@ -43,7 +43,7 @@ impl_par_dist! {
 
 	impl<P: ParallelPipe<Input>, F, R: Stream, Input> ParallelPipe<Input> for FlatMap<P, F>
 	where
-		F: FnMut<(P::Output,), Output = R> + Clone + Send + 'static,
+		F: FnMut<(P::Output,), Output = R> + Clone + Send,
 	{
 		type Output = R::Item;
 		type Task = FlatMapTask<P::Task, F>;

--- a/amadeus-core/src/par_stream/identity.rs
+++ b/amadeus-core/src/par_stream/identity.rs
@@ -46,7 +46,7 @@ mod workaround {
 		#[inline]
 		pub fn inspect<F>(self, f: F) -> Inspect<Self, F>
 		where
-			F: Clone + Send + 'static,
+			F: Clone + Send,
 		{
 			Inspect::new(self, f)
 		}
@@ -54,7 +54,7 @@ mod workaround {
 		#[inline]
 		pub fn update<T, F>(self, f: F) -> Update<Self, F>
 		where
-			F: Clone + Send + 'static,
+			F: Clone + Send,
 		{
 			Update::new(self, f)
 		}
@@ -62,7 +62,7 @@ mod workaround {
 		#[inline]
 		pub fn map<F>(self, f: F) -> Map<Self, F>
 		where
-			F: Clone + Send + 'static,
+			F: Clone + Send,
 		{
 			Map::new(self, f)
 		}
@@ -70,7 +70,7 @@ mod workaround {
 		#[inline]
 		pub fn flat_map<F>(self, f: F) -> FlatMap<Self, F>
 		where
-			F: Clone + Send + 'static,
+			F: Clone + Send,
 		{
 			FlatMap::new(self, f)
 		}
@@ -78,7 +78,7 @@ mod workaround {
 		#[inline]
 		pub fn filter<F>(self, f: F) -> Filter<Self, F>
 		where
-			F: Clone + Send + 'static,
+			F: Clone + Send,
 		{
 			Filter::new(self, f)
 		}
@@ -95,7 +95,7 @@ mod workaround {
 		#[inline]
 		pub fn for_each<F>(self, f: F) -> ForEach<Self, F>
 		where
-			F: Clone + Send + 'static,
+			F: Clone + Send,
 		{
 			ForEach::new(self, f)
 		}
@@ -103,9 +103,9 @@ mod workaround {
 		#[inline]
 		pub fn fold<ID, F, B>(self, identity: ID, op: F) -> Fold<Self, ID, F, B>
 		where
-			ID: traits::FnMut() -> B + Clone + Send + 'static,
-			F: Clone + Send + 'static,
-			B: Send + 'static,
+			ID: traits::FnMut() -> B + Clone + Send,
+			F: Clone + Send,
+			B: Send,
 		{
 			Fold::new(self, identity, op)
 		}
@@ -128,7 +128,7 @@ mod workaround {
 		#[inline]
 		pub fn sum<B>(self) -> Sum<Self, B>
 		where
-			B: iter::Sum<B> + Send + 'static,
+			B: iter::Sum<B> + Send,
 		{
 			Sum::new(self)
 		}
@@ -136,7 +136,7 @@ mod workaround {
 		#[inline]
 		pub fn combine<F>(self, f: F) -> Combine<Self, F>
 		where
-			F: Clone + Send + 'static,
+			F: Clone + Send,
 		{
 			Combine::new(self, f)
 		}
@@ -149,7 +149,7 @@ mod workaround {
 		#[inline]
 		pub fn max_by<F>(self, f: F) -> MaxBy<Self, F>
 		where
-			F: Clone + Send + 'static,
+			F: Clone + Send,
 		{
 			MaxBy::new(self, f)
 		}
@@ -157,7 +157,7 @@ mod workaround {
 		#[inline]
 		pub fn max_by_key<F>(self, f: F) -> MaxByKey<Self, F>
 		where
-			F: Clone + Send + 'static,
+			F: Clone + Send,
 		{
 			MaxByKey::new(self, f)
 		}
@@ -170,7 +170,7 @@ mod workaround {
 		#[inline]
 		pub fn min_by<F>(self, f: F) -> MinBy<Self, F>
 		where
-			F: Clone + Send + 'static,
+			F: Clone + Send,
 		{
 			MinBy::new(self, f)
 		}
@@ -178,7 +178,7 @@ mod workaround {
 		#[inline]
 		pub fn min_by_key<F>(self, f: F) -> MinByKey<Self, F>
 		where
-			F: Clone + Send + 'static,
+			F: Clone + Send,
 		{
 			MinByKey::new(self, f)
 		}
@@ -205,7 +205,7 @@ mod workaround {
 		#[inline]
 		pub fn all<F>(self, f: F) -> All<Self, F>
 		where
-			F: Clone + Send + 'static,
+			F: Clone + Send,
 		{
 			All::new(self, f)
 		}
@@ -213,7 +213,7 @@ mod workaround {
 		#[inline]
 		pub fn any<F>(self, f: F) -> Any<Self, F>
 		where
-			F: Clone + Send + 'static,
+			F: Clone + Send,
 		{
 			Any::new(self, f)
 		}

--- a/amadeus-core/src/par_stream/inspect.rs
+++ b/amadeus-core/src/par_stream/inspect.rs
@@ -22,7 +22,7 @@ pub struct Inspect<P, F> {
 impl_par_dist! {
 	impl<P: ParallelStream, F> ParallelStream for Inspect<P, F>
 	where
-		F: for<'a> FnMut<(&'a P::Item,), Output = ()> + Clone + Send + 'static,
+		F: for<'a> FnMut<(&'a P::Item,), Output = ()> + Clone + Send,
 	{
 		type Item = P::Item;
 		type Task = InspectTask<P::Task, F>;
@@ -44,7 +44,7 @@ impl_par_dist! {
 
 	impl<P: ParallelPipe<Input>, F, Input> ParallelPipe<Input> for Inspect<P, F>
 	where
-		F: for<'a> FnMut<(&'a P::Output,), Output = ()> + Clone + Send + 'static,
+		F: for<'a> FnMut<(&'a P::Output,), Output = ()> + Clone + Send,
 	{
 		type Output = P::Output;
 		type Task = InspectTask<P::Task, F>;

--- a/amadeus-core/src/par_stream/map.rs
+++ b/amadeus-core/src/par_stream/map.rs
@@ -20,7 +20,7 @@ pub struct Map<P, F> {
 impl_par_dist! {
 	impl<P: ParallelStream, F, R> ParallelStream for Map<P, F>
 	where
-		F: FnMut<(P::Item,), Output = R> + Clone + Send + 'static,
+		F: FnMut<(P::Item,), Output = R> + Clone + Send,
 	{
 		type Item = R;
 		type Task = MapTask<P::Task, F>;
@@ -42,7 +42,7 @@ impl_par_dist! {
 
 	impl<P: ParallelPipe<Input>, F, R, Input> ParallelPipe<Input> for Map<P, F>
 	where
-		F: FnMut<(P::Output,), Output = R> + Clone + Send + 'static,
+		F: FnMut<(P::Output,), Output = R> + Clone + Send,
 	{
 		type Output = R;
 		type Task = MapTask<P::Task, F>;

--- a/amadeus-core/src/par_stream/update.rs
+++ b/amadeus-core/src/par_stream/update.rs
@@ -22,7 +22,7 @@ pub struct Update<P, F> {
 impl_par_dist! {
 	impl<P: ParallelStream, F> ParallelStream for Update<P, F>
 	where
-		F: for<'a> FnMut<(&'a mut P::Item,), Output = ()> + Clone + Send + 'static,
+		F: for<'a> FnMut<(&'a mut P::Item,), Output = ()> + Clone + Send,
 	{
 		type Item = P::Item;
 		type Task = UpdateTask<P::Task, F>;
@@ -44,7 +44,7 @@ impl_par_dist! {
 
 	impl<P: ParallelPipe<Input>, F, Input> ParallelPipe<Input> for Update<P, F>
 	where
-		F: for<'a> FnMut<(&'a mut P::Output,), Output = ()> + Clone + Send + 'static,
+		F: for<'a> FnMut<(&'a mut P::Output,), Output = ()> + Clone + Send,
 	{
 		type Output = P::Output;
 		type Task = UpdateTask<P::Task, F>;

--- a/amadeus-parquet/src/lib.rs
+++ b/amadeus-parquet/src/lib.rs
@@ -84,7 +84,7 @@ mod wrap {
 	impl<F, Row> Parquet<F, Row>
 	where
 		F: File,
-		Row: ParquetData + 'static,
+		Row: ParquetData,
 	{
 		pub async fn new(file: F) -> Result<Self, <Self as Source>::Error> {
 			Ok(Self {
@@ -96,7 +96,7 @@ mod wrap {
 	impl<F, Row> Source for Parquet<F, Row>
 	where
 		F: File,
-		Row: ParquetData + 'static,
+		Row: ParquetData,
 	{
 		type Item = Row;
 		#[allow(clippy::type_complexity)]

--- a/amadeus-types/src/list.rs
+++ b/amadeus-types/src/list.rs
@@ -384,7 +384,7 @@ impl<T: Data> ListVec<T> for Vec<T> {
 
 impl<T: Data> FromParallelStream<T> for List<T>
 where
-	T: Send + 'static,
+	T: Send,
 {
 	type ReduceA = PushReducer<T, Self>;
 	type ReduceC = ExtendReducer<Self>;
@@ -396,7 +396,7 @@ where
 
 impl<T: Data> FromDistributedStream<T> for List<T>
 where
-	T: ProcessSend + 'static,
+	T: ProcessSend,
 {
 	type ReduceA = PushReducer<T, Self>;
 	type ReduceB = ExtendReducer<Self>;

--- a/benches/in_memory.rs
+++ b/benches/in_memory.rs
@@ -30,7 +30,7 @@ fn vec(b: &mut Bencher) {
 	run(b, bytes, || async {
 		assert_eq!(
 			rows.par_stream()
-				.map(|x| x as u64)
+				.map(|&x| x as u64)
 				.sum::<_, u64>(&*POOL)
 				.await,
 			sum

--- a/src/source.rs
+++ b/src/source.rs
@@ -169,7 +169,6 @@ impl<I, T, E, U> ParallelStream for IntoStream<I, U>
 where
 	I: ParallelStream<Item = Result<T, E>>,
 	T: Into<U>,
-	U: 'static,
 {
 	type Item = Result<U, E>;
 	type Task = IntoTask<I::Task, U>;
@@ -190,7 +189,6 @@ impl<I, T, E, U> DistributedStream for IntoStream<I, U>
 where
 	I: DistributedStream<Item = Result<T, E>>,
 	T: Into<U>,
-	U: 'static,
 {
 	type Item = Result<U, E>;
 	type Task = IntoTask<I::Task, U>;


### PR DESCRIPTION
This enables big performance improvements by not having to clone elements for `ParallelStream`s.

The complication is that, akin to [`crossbeam::scope`](https://docs.rs/crossbeam/0.7/crossbeam/fn.scope.html), we need to block before returning to avoid the user `mem::forget`ting the handle and mutating the data while other threads still have a reference to it. If we were sync (like for example `rayon`) this wouldn't be much of an issue. As we're async and have to return whenever I/O blocks, this is harder to deal with.

The current compromise in this PR is using `tokio` to block the current task (when running under the [multithreaded scheduler](https://docs.rs/tokio/0.2.22/tokio/runtime/index.html#threaded-scheduler)) or current thread (when running under the [basic scheduler](https://docs.rs/tokio/0.2.22/tokio/runtime/index.html#basic-scheduler)). This is unfortunately mildly surprising from a user POV, and a little hairy given it seems to trigger tokio to hang. WIP.